### PR TITLE
fix(auth): hydration-safe AuthProvider — 모바일 Hydration Error 차단

### DIFF
--- a/lib/supabase/auth-provider.tsx
+++ b/lib/supabase/auth-provider.tsx
@@ -37,16 +37,46 @@ interface AuthProviderProps {
   children: ReactNode;
 }
 
+// Hydration-safe initial state. Both SSR and the first CSR render must produce
+// the SAME tree, otherwise React reports "Hydration failed - the server
+// rendered HTML didn't match the client." The previous initializer
+// (`AuthStore.getInstance().getState()`) could diverge on mobile browsers
+// (Samsung Internet / Chrome Mobile / Safari Mobile) when the AuthStore
+// singleton's window-side init produced different visible state during
+// hydration than what SSR computed (cookie/localStorage timing skew). We now
+// hand-build a stable empty state for the first render on both sides, then
+// hydrate from the real store inside useEffect — guaranteeing identical first
+// paint regardless of platform.
+const NOOP_SIGN_OUT: AuthContextType['signOut'] = async () => {};
+const NOOP_LOAD_USER_PROFILE: AuthContextType['loadUserProfile'] = async () => null;
+
+const SSR_SAFE_INITIAL_STATE: AuthContextType = {
+  session: null,
+  user: null,
+  userProfile: null,
+  isAuthenticated: false,
+  isLoading: true,
+  isInitialized: false,
+  signOut: NOOP_SIGN_OUT,
+  loadUserProfile: NOOP_LOAD_USER_PROFILE,
+};
+
 // AuthProvider 컴포넌트를 memo로 감싸서 완전히 안정화
 const AuthProviderComponent = memo(function AuthProviderInternal({ children }: AuthProviderProps) {
   debugLog('🏗️ [AuthProvider] 컴포넌트 생성/재렌더링');
 
-  const [contextValue, setContextValue] = useState<AuthContextType>(() => {
-    return AuthStore.getInstance().getState();
-  });
+  // First render must be deterministic between SSR and CSR — never read the
+  // singleton state here. The real store state is synced in the effect below.
+  const [contextValue, setContextValue] = useState<AuthContextType>(SSR_SAFE_INITIAL_STATE);
 
   useEffect(() => {
     const authStore = AuthStore.getInstance();
+
+    // Sync immediately to whatever the store currently holds. This may produce
+    // a second render with the actual session/user, but since this runs after
+    // mount it cannot trigger hydration mismatch — the first render already
+    // matched SSR's empty state.
+    setContextValue(authStore.getState());
 
     const initializeAndSubscribe = async () => {
       try {


### PR DESCRIPTION
## Summary
PR #3 cookie 마이그레이션 배포 후 발생한 모바일 Hydration Error 23건+의 근본 원인 추정 수정.

## 증상 (Sentry 7441368588)
- **URL 분포**: `/en/vote/225` 29건, `/en/mypage` 16건, `/ko/vote/225` 3건 등
- **환경**: Samsung Internet 33 / Chrome Mobile 13 / Mobile Safari 6 — **모바일 only**, desktop 0
- **Subtitle**: \`Hydration failed - the server rendered HTML didn't match the client.\`
- **React**: 19.2.0-canary (Next.js bundled)
- **추세**: 머지 후 ~25h 부터 시작, 평균 +7건/10분 (4명 사용자 반복 발생)

## 근본 원인 (가설, 고확률)
\`AuthProvider\`의 \`useState\` initializer가 \`AuthStore.getInstance().getState()\` 호출:
- AuthStore 싱글톤은 constructor 내부에 \`if (typeof window !== 'undefined')\` 블록이 있어 client에서 cookie 검사 등 동기 로직 실행
- **SSR**: window 블록 skip → empty state
- **CSR 첫 hydration**: window 블록 실행 → 일부 state 변화 가능
- 모바일 브라우저는 cookie 처리 타이밍 차이로 mismatch 발현 빈도 높음

## 변경
\`lib/supabase/auth-provider.tsx\`:
- \`SSR_SAFE_INITIAL_STATE\` 상수 추가 (모든 필드 null/false/loading)
- \`useState(SSR_SAFE_INITIAL_STATE)\` — SSR/CSR 첫 render 동일성 보장
- \`useEffect\` 내부 첫 줄에 \`setContextValue(authStore.getState())\` 즉시 동기화 → 두 번째 render부터 실제 session

## UX 영향
- 첫 render: 모든 환경에서 "guest" 상태로 hydration 통과
- mount 직후 (~한 frame 내): 실제 session으로 update
- **flash 가능성**: mypage 등 user-dependent UI가 잠시 logged-out 상태로 보일 수 있으나, 기존에도 contextValue.subscribe 기반 update가 있었으므로 차이 미미

## 한계 (정직한 공개)
Sentry가 React 19 Generic Hydration occurrence 형식이라 **정확한 diff 위치를 못 잡음**. 본 수정은:
- ✅ AuthState 기반 mismatch 가설(고확률) 차단
- ⚠️ 만약 다른 원인(모바일 viewport, date locale, 다른 client component의 `typeof window` 분기 등)이 있다면 잔존 가능 → 배포 후 24h 모니터링 후 후속 조사

## Test plan
- [x] \`npm run build\` 성공 (Compiled in 35.7s)
- [ ] Staging에서 Samsung Internet (Android 10) emulation으로 vote/[id], mypage 진입
- [ ] 배포 후 24h Sentry 7441368588 재발 빈도 확인 (목표: cnt 증가율 0)
- [ ] Sentry Replay (id: 8fd4187c14c5434784bfa42ed283663c) 재생해서 정확한 diff 위치 확인

## 후속 (별건 고려)
- 만약 본 수정 후에도 Hydration Error 잔존 → 다른 client component의 \`typeof window\` 사용처 전수 감사
- AuthProvider뿐 아니라 다른 \`useState(() => ...)\` 패턴도 동일 수정 권장 (예: \`stores/*\` Zustand store hydration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)