### PR TITLE
fix(security): presign 인증 + proxy-image SSRF 차단 (Group A)

### DIFF
--- a/app/api/proxy-image/route.ts
+++ b/app/api/proxy-image/route.ts
@@ -3,142 +3,186 @@ import { NextRequest, NextResponse } from 'next/server';
 /**
  * 이미지 프록시 API
  * Google 이미지 429 에러를 우회하기 위해 서버에서 이미지를 프록시합니다.
+ *
+ * SECURITY: redirect는 수동으로 처리하여 SSRF를 차단합니다. 자동 redirect를
+ * 허용하면 허용 도메인이 169.254.169.254 (cloud metadata)나 internal address로
+ * 302 응답을 줄 때 서버가 그대로 따라가 내부 네트워크를 노출하게 됩니다.
+ * CORS는 원본 와일드카드(*) 대신 자체 origin 화이트리스트로 echo합니다.
  */
+
+const ALLOWED_DOMAINS_BASE = [
+  'googleusercontent.com',
+  'lh3.googleusercontent.com',
+  'graph.facebook.com',
+  'pbs.twimg.com',
+  'cdn.discordapp.com',
+  'avatars.githubusercontent.com',
+];
+
+const SUPABASE_WILDCARD_SUFFIXES = ['.supabase.co', '.supabase.in'];
+
+const FETCH_TIMEOUT_MS = 10_000;
+const MAX_REDIRECT_DEPTH = 1;
+
+function buildAllowedDomains(): string[] {
+  const list = [...ALLOWED_DOMAINS_BASE];
+  try {
+    const supabaseUrl =
+      process.env.NEXT_PUBLIC_SUPABASE_URL ?? process.env.SUPABASE_URL;
+    if (supabaseUrl) list.push(new URL(supabaseUrl).host);
+  } catch {
+    // ignore — env may be malformed in some contexts
+  }
+  return list;
+}
+
+function isHostAllowed(hostname: string, allowedDomains: string[]): boolean {
+  return (
+    allowedDomains.some(
+      (d) => hostname === d || hostname.endsWith('.' + d),
+    ) ||
+    SUPABASE_WILDCARD_SUFFIXES.some((suffix) => hostname.endsWith(suffix))
+  );
+}
+
+function getAllowedOrigins(): string[] {
+  const list: string[] = [];
+  for (const env of [
+    process.env.NEXT_PUBLIC_SITE_URL,
+    process.env.BASE_URL,
+    process.env.NEXT_PUBLIC_STAGING_URL,
+  ]) {
+    if (typeof env === 'string' && env) {
+      try {
+        list.push(new URL(env).origin);
+      } catch {
+        // skip invalid
+      }
+    }
+  }
+  if (process.env.NODE_ENV !== 'production') {
+    list.push('http://localhost:3000', 'http://localhost:3100');
+  }
+  if (list.length === 0) list.push('https://www.picnic.fan');
+  return Array.from(new Set(list));
+}
+
+function corsHeaders(requestOrigin: string | null): Record<string, string> {
+  const headers: Record<string, string> = {
+    Vary: 'Origin',
+    'Access-Control-Allow-Methods': 'GET, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+  };
+  if (requestOrigin && getAllowedOrigins().includes(requestOrigin)) {
+    headers['Access-Control-Allow-Origin'] = requestOrigin;
+  }
+  return headers;
+}
+
+async function fetchWithRedirectGuard(
+  initialUrl: string,
+  allowedDomains: string[],
+): Promise<Response> {
+  let currentUrl = initialUrl;
+  for (let depth = 0; depth <= MAX_REDIRECT_DEPTH; depth++) {
+    const response = await fetch(currentUrl, {
+      redirect: 'manual',
+      headers: {
+        'User-Agent': 'Mozilla/5.0 (compatible; PicnicBot/1.0)',
+        Accept: 'image/*',
+        'Cache-Control': 'no-cache',
+      },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get('location');
+      if (!location) return response;
+      let nextUrl: URL;
+      try {
+        nextUrl = new URL(location, currentUrl);
+      } catch {
+        throw new Error('invalid redirect target');
+      }
+      if (!isHostAllowed(nextUrl.hostname, allowedDomains)) {
+        throw new Error('redirect target not in allowlist');
+      }
+      currentUrl = nextUrl.toString();
+      continue;
+    }
+
+    return response;
+  }
+  throw new Error('redirect depth exceeded');
+}
+
 export async function GET(request: NextRequest) {
+  const requestOrigin = request.headers.get('origin');
+  const cors = corsHeaders(requestOrigin);
+
   try {
     const { searchParams } = new URL(request.url);
     const imageUrl = searchParams.get('url');
-    
-    if (!imageUrl) {
-      return NextResponse.json(
-        { error: '이미지 URL이 필요합니다.' },
-        { status: 400 }
-      );
-    }
-    
-    // URL 검증
-    try {
-      const url = new URL(imageUrl);
-      
-      // 허용된 도메인만 프록시
-      const allowedDomains = [
-        'googleusercontent.com',
-        'lh3.googleusercontent.com',
-        'graph.facebook.com',
-        'pbs.twimg.com',
-        'cdn.discordapp.com',
-        'avatars.githubusercontent.com',
-      ];
 
-      try {
-        const supabaseUrl =
-          process.env.NEXT_PUBLIC_SUPABASE_URL ?? process.env.SUPABASE_URL;
-        if (supabaseUrl) {
-          const supabaseHost = new URL(supabaseUrl).host;
-          allowedDomains.push(supabaseHost);
-        }
-      } catch (error) {
-        console.warn('🖼️ [ImageProxy] Supabase 도메인 파싱 실패:', error);
-      }
-      
-      const supabaseWildcardDomains = [
-        '.supabase.co',
-        '.supabase.in',
-      ];
-      
-      const isAllowed =
-        allowedDomains.some((domain) => url.hostname === domain || url.hostname.endsWith('.' + domain)) ||
-        supabaseWildcardDomains.some((suffix) =>
-          url.hostname.endsWith(suffix),
-        );
-      
-      if (!isAllowed) {
-        return NextResponse.json(
-          { error: '허용되지 않은 도메인입니다.' },
-          { status: 403 }
-        );
-      }
-    } catch (error) {
-      return NextResponse.json(
-        { error: '유효하지 않은 URL입니다.' },
-        { status: 400 }
-      );
+    if (!imageUrl) {
+      return NextResponse.json({ error: 'invalid request' }, { status: 400, headers: cors });
     }
-    
-    // 이미지 가져오기
-    const response = await fetch(imageUrl, {
-      headers: {
-        'User-Agent': 'Mozilla/5.0 (compatible; PicnicBot/1.0)',
-        'Accept': 'image/*',
-        'Cache-Control': 'no-cache'
-      },
-      // 타임아웃 설정
-      signal: AbortSignal.timeout(10000) // 10초
-    });
-    
+
+    let parsed: URL;
+    try {
+      parsed = new URL(imageUrl);
+    } catch {
+      return NextResponse.json({ error: 'invalid request' }, { status: 400, headers: cors });
+    }
+
+    const allowedDomains = buildAllowedDomains();
+    if (!isHostAllowed(parsed.hostname, allowedDomains)) {
+      return NextResponse.json({ error: 'host not allowed' }, { status: 403, headers: cors });
+    }
+
+    const response = await fetchWithRedirectGuard(imageUrl, allowedDomains);
+
     if (!response.ok) {
-      console.warn(`🖼️ [ImageProxy] 이미지 로딩 실패: ${response.status} ${response.statusText} for ${imageUrl}`);
-      
-      // 429 에러인 경우 특별 처리
+      console.warn(
+        `🖼️ [ImageProxy] fetch failed: ${response.status} ${response.statusText}`,
+      );
       if (response.status === 429) {
         return NextResponse.json(
-          { 
-            error: 'Too Many Requests', 
+          {
+            error: 'Too Many Requests',
             message: '이미지 서버에서 요청 제한이 발생했습니다.',
-            retryAfter: response.headers.get('Retry-After') || '300'
+            retryAfter: response.headers.get('Retry-After') || '300',
           },
-          { status: 429 }
+          { status: 429, headers: cors },
         );
       }
-      
-      return NextResponse.json(
-        { error: `이미지 로딩 실패: ${response.status}` },
-        { status: response.status }
-      );
+      return NextResponse.json({ error: 'fetch failed' }, { status: response.status, headers: cors });
     }
-    
+
     const contentType = response.headers.get('content-type') || 'image/jpeg';
     const imageBuffer = await response.arrayBuffer();
-    
-    // 이미지 응답 반환
+
     return new NextResponse(imageBuffer, {
       status: 200,
       headers: {
+        ...cors,
         'Content-Type': contentType,
-        'Cache-Control': 'public, max-age=3600, s-maxage=86400', // 1시간 브라우저 캐시, 1일 CDN 캐시
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Methods': 'GET',
-        'Access-Control-Allow-Headers': 'Content-Type'
-      }
+        'Cache-Control': 'public, max-age=3600, s-maxage=86400',
+      },
     });
-    
   } catch (error) {
-    console.error('🖼️ [ImageProxy] 프록시 에러:', error);
-    
-    // 타임아웃 에러
+    console.error('🖼️ [ImageProxy] proxy error:', error);
     if (error instanceof Error && error.name === 'TimeoutError') {
-      return NextResponse.json(
-        { error: '이미지 로딩 시간 초과' },
-        { status: 504 }
-      );
+      return NextResponse.json({ error: 'timeout' }, { status: 504, headers: cors });
     }
-    
-    return NextResponse.json(
-      { error: '이미지 프록시 처리 중 오류가 발생했습니다.' },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: 'fetch failed' }, { status: 500, headers: cors });
   }
 }
 
-// OPTIONS 요청 처리 (CORS)
-export async function OPTIONS() {
+export async function OPTIONS(request: NextRequest) {
+  const requestOrigin = request.headers.get('origin');
   return new NextResponse(null, {
-    status: 200,
-    headers: {
-      'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'GET, OPTIONS',
-      'Access-Control-Allow-Headers': 'Content-Type'
-    }
+    status: 204,
+    headers: corsHeaders(requestOrigin),
   });
 }
-

--- a/app/api/uploads/presign/route.ts
+++ b/app/api/uploads/presign/route.ts
@@ -1,37 +1,97 @@
-import { NextRequest, NextResponse } from 'next/server'
-import { createPresignedPost } from '@aws-sdk/s3-presigned-post'
-import { S3Client } from '@aws-sdk/client-s3'
+import { NextRequest, NextResponse } from 'next/server';
+import { createPresignedPost } from '@aws-sdk/s3-presigned-post';
+import { S3Client } from '@aws-sdk/client-s3';
+import { randomUUID } from 'crypto';
+import { getServerUser } from '@/lib/supabase/server';
 
 const s3 = new S3Client({
   region: process.env.AWS_REGION,
-  credentials: process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY ? {
-    accessKeyId: process.env.AWS_ACCESS_KEY_ID,
-    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
-  } : undefined,
-})
+  credentials:
+    process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY
+      ? {
+          accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+          secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+        }
+      : undefined,
+});
+
+const ALLOWED_CONTENT_TYPES = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+  'image/avif',
+  'video/mp4',
+  'video/webm',
+  'video/quicktime',
+]);
+
+const EXT_BY_TYPE: Record<string, string> = {
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/gif': 'gif',
+  'image/webp': 'webp',
+  'image/avif': 'avif',
+  'video/mp4': 'mp4',
+  'video/webm': 'webm',
+  'video/quicktime': 'mov',
+};
+
+const MAX_UPLOAD_BYTES = 20 * 1024 * 1024;
 
 export async function POST(req: NextRequest) {
   try {
-    const { filename, contentType } = await req.json()
-    const bucket = process.env.S3_BUCKET as string
-    if (!bucket) return NextResponse.json({ error: 'No bucket configured' }, { status: 500 })
+    // Authentication: only logged-in users may obtain presigned upload URLs.
+    // Without this, any unauthenticated client could upload arbitrary files
+    // (including HTML/JS) into the posts/ prefix up to MAX_UPLOAD_BYTES.
+    const user = await getServerUser();
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
 
-    const key = `posts/${Date.now()}_${encodeURIComponent(filename)}`
+    const bucket = process.env.S3_BUCKET as string;
+    if (!bucket) {
+      console.error('S3_BUCKET env var not configured');
+      return NextResponse.json({ error: 'Server misconfigured' }, { status: 500 });
+    }
+
+    const body = (await req.json().catch(() => null)) as
+      | { contentType?: unknown; filename?: unknown }
+      | null;
+    const contentType = typeof body?.contentType === 'string' ? body.contentType : '';
+
+    if (!ALLOWED_CONTENT_TYPES.has(contentType)) {
+      return NextResponse.json(
+        { error: 'Unsupported content type' },
+        { status: 415 }
+      );
+    }
+
+    // Server-derived key. The client-supplied filename is intentionally NOT
+    // used in the S3 path to prevent path traversal and to keep uploads
+    // namespaced under the authenticated user's ID for ownership checks.
+    const ext = EXT_BY_TYPE[contentType] ?? 'bin';
+    const key = `posts/${user.id}/${randomUUID()}.${ext}`;
+
     const { url, fields } = await createPresignedPost(s3, {
       Bucket: bucket,
       Key: key,
       Conditions: [
-        ['content-length-range', 0, 20 * 1024 * 1024],
-        ['starts-with', '$Content-Type', ''],
+        ['content-length-range', 0, MAX_UPLOAD_BYTES],
+        ['eq', '$Content-Type', contentType],
       ],
       Expires: 60,
-      Fields: { 'Content-Type': contentType || 'application/octet-stream' },
-    })
+      Fields: { 'Content-Type': contentType },
+    });
 
-    return NextResponse.json({ url, fields, key, publicUrl: `https://${bucket}.s3.${process.env.AWS_REGION}.amazonaws.com/${key}` })
+    return NextResponse.json({
+      url,
+      fields,
+      key,
+      publicUrl: `https://${bucket}.s3.${process.env.AWS_REGION}.amazonaws.com/${key}`,
+    });
   } catch (e) {
-    return NextResponse.json({ error: 'failed to presign' }, { status: 500 })
+    console.error('presign error:', e);
+    return NextResponse.json({ error: 'failed to presign' }, { status: 500 });
   }
 }
-
-


### PR DESCRIPTION
## Summary
이전 코드 리뷰에서 Major로 분류된 2개 Critical 보안 결함 수정.

## S1 (Critical) — uploads/presign 인증 부재
- 비인증 사용자가 임의 파일 20MB 업로드 가능 (HTML/JS 포함)
- 수정: getServerUser() 인증 체크 + content-type 화이트리스트 + UUID 기반 key

## S2 (Critical) — proxy-image SSRF + 오픈 CORS
- 허용 도메인이 169.254.169.254로 redirect 시 cloud metadata 노출 가능
- 수정: redirect: 'manual' + Location 호스트 재검증 (depth 1) + CORS 화이트리스트

## Test plan
- [x] npm run build 성공
- [ ] Staging에서 비로그인 상태로 /api/uploads/presign POST → 401
- [ ] Staging에서 로그인 상태로 application/octet-stream → 415
- [ ] Staging에서 imagebench redirect to internal IP 시도 → 차단

🤖 Generated with [Claude Code](https://claude.com/claude-code)