### PR TITLE
fix(frontend): Quill leak, Notification timers, CommentList refetch, useInfiniteScroll closure (Group C)

### DIFF
--- a/components/community/CommentList.tsx
+++ b/components/community/CommentList.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React, { useState, useTransition } from 'react'
+import { useRouter } from 'next/navigation'
 import QuillDeltaRenderer from '@/lib/content/quill-delta-renderer'
 import { useTranslations } from '@/hooks/useTranslations'
 import { useNotification } from '@/contexts/NotificationContext'
@@ -242,7 +243,7 @@ function CommentItemComponent({
 
 export default function CommentList({ comments, lang = 'ko', postId }: CommentListProps) {
   const { t } = useTranslations()
-  const [, forceUpdate] = useState(0)
+  const router = useRouter()
 
   // 부모 댓글과 대댓글 분리
   const parentComments = comments.filter(c => !c.parentCommentId)
@@ -255,8 +256,11 @@ export default function CommentList({ comments, lang = 'ko', postId }: CommentLi
     repliesMap.get(parentId)!.push(c)
   })
 
+  // Reply가 성공해도 comments는 server prop이라 forceUpdate(n+1)만으로는
+  // 새 reply가 화면에 안 나타남. router.refresh()로 server data를 다시 받아
+  // 부모 page를 재렌더해야 함.
   const handleReplySuccess = () => {
-    forceUpdate(n => n + 1)
+    router.refresh()
   }
 
   if (!parentComments.length) return <p className='text-sm text-gray-700'>{t('community.commentList.noComments')}</p>

--- a/components/community/QuillBasicEditor.tsx
+++ b/components/community/QuillBasicEditor.tsx
@@ -10,6 +10,7 @@ export default function QuillBasicEditor({ value, onChange, minHeight = 600 }: {
 
   useEffect(() => {
     let isMounted = true
+    let textChangeHandler: (() => void) | null = null
     ;(async () => {
       const Quill = (await import('quill')).default
       if (!isMounted || !editorRef.current) return
@@ -35,13 +36,32 @@ export default function QuillBasicEditor({ value, onChange, minHeight = 600 }: {
             el.style.minHeight = `${minHeight}px`
           }
         } catch {}
-        quillRef.current.on('text-change', () => {
+        textChangeHandler = () => {
+          if (!isMounted || !quillRef.current) return
           const delta = quillRef.current.getContents()
           onChange(delta)
-        })
+        }
+        quillRef.current.on('text-change', textChangeHandler)
       }
     })()
-    return () => { isMounted = false }
+    return () => {
+      isMounted = false
+      // Detach the listener and drop the Quill instance so the editor DOM,
+      // toolbar, and text-change subscribers are eligible for GC. Without
+      // this, navigating away from the editor leaks the entire Quill
+      // instance and can fire onChange after unmount (setState warnings).
+      if (quillRef.current) {
+        try {
+          if (textChangeHandler) {
+            quillRef.current.off('text-change', textChangeHandler)
+          }
+          // Quill has no .destroy(); clearing the host node and dropping
+          // the ref is the documented teardown pattern.
+          if (editorRef.current) editorRef.current.innerHTML = ''
+        } catch {}
+        quillRef.current = null
+      }
+    }
   }, [])
 
   useEffect(() => {

--- a/contexts/NotificationContext.tsx
+++ b/contexts/NotificationContext.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { createContext, useContext, useState, useCallback, ReactNode, useEffect } from 'react';
+import React, { createContext, useContext, useState, useCallback, useRef, ReactNode, useEffect } from 'react';
 import { SUPABASE_AUTH_RATE_LIMIT_EVENT, SupabaseAuthRateLimitDetail } from '@/lib/supabase/events';
 import { useTranslations } from '@/hooks/useTranslations';
 
@@ -37,9 +37,29 @@ interface NotificationProviderProps {
 export function NotificationProvider({ children }: NotificationProviderProps) {
   const [notifications, setNotifications] = useState<NotificationState[]>([]);
   const { t } = useTranslations();
+  // Track active dismiss timers so we can cancel them on unmount or when
+  // a notification is removed early. The previous implementation never
+  // cleared its setTimeout handles, leaving setState callbacks armed past
+  // unmount and producing setState-on-unmounted warnings.
+  const timersRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+  const removeNotification = useCallback((id: string) => {
+    const timer = timersRef.current.get(id);
+    if (timer) {
+      clearTimeout(timer);
+      timersRef.current.delete(id);
+    }
+    setNotifications(prev => prev.filter(notification => notification.id !== id));
+  }, []);
 
   const addNotification = useCallback((notification: Omit<NotificationState, 'id' | 'timestamp'>) => {
-    const id = Math.random().toString(36).substr(2, 9);
+    // crypto.randomUUID() is collision-safe; the previous Math.random().substr
+    // pattern produced ~10-byte ids that could clash on rapid successive
+    // notifications and used the deprecated substr() API.
+    const id =
+      typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+        ? crypto.randomUUID()
+        : `n_${Date.now()}_${Math.random().toString(36).slice(2, 11)}`;
     const newNotification: NotificationState = {
       ...notification,
       id,
@@ -48,21 +68,29 @@ export function NotificationProvider({ children }: NotificationProviderProps) {
 
     setNotifications(prev => [...prev, newNotification]);
 
-    // 자동 제거 (기본 5초, 또는 지정된 duration)
     const duration = notification.duration || 5000;
     if (duration > 0) {
-      setTimeout(() => {
+      const timer = setTimeout(() => {
+        timersRef.current.delete(id);
         setNotifications(prev => prev.filter(n => n.id !== id));
       }, duration);
+      timersRef.current.set(id, timer);
     }
   }, []);
 
-  const removeNotification = useCallback((id: string) => {
-    setNotifications(prev => prev.filter(notification => notification.id !== id));
+  const clearAllNotifications = useCallback(() => {
+    for (const timer of Array.from(timersRef.current.values())) clearTimeout(timer);
+    timersRef.current.clear();
+    setNotifications([]);
   }, []);
 
-  const clearAllNotifications = useCallback(() => {
-    setNotifications([]);
+  // Clear any pending dismiss timers on unmount.
+  useEffect(() => {
+    const timers = timersRef.current;
+    return () => {
+      for (const timer of Array.from(timers.values())) clearTimeout(timer);
+      timers.clear();
+    };
   }, []);
 
   useEffect(() => {

--- a/hooks/useInfiniteScroll.ts
+++ b/hooks/useInfiniteScroll.ts
@@ -12,6 +12,22 @@ interface UseInfiniteScrollOptions<T> {
 export function useInfiniteScroll<T>(options: UseInfiniteScrollOptions<T>) {
   const { apiEndpoint, limit = 10, onSuccess, onError, transform } = options;
 
+  // Stable refs for callbacks/transform so fetchData identity stays stable
+  // across renders even when callers pass inline arrow functions. The prior
+  // implementation listed onSuccess/onError/transform in fetchData's deps,
+  // making fetchData re-create every render and re-arming the
+  // IntersectionObserver effect (deps include fetchData). Combined with the
+  // initial-load effect's empty deps, the first call closed over a stale
+  // fetchData on first render.
+  const onSuccessRef = useRef(onSuccess);
+  const onErrorRef = useRef(onError);
+  const transformRef = useRef(transform);
+  useEffect(() => {
+    onSuccessRef.current = onSuccess;
+    onErrorRef.current = onError;
+    transformRef.current = transform;
+  }, [onSuccess, onError, transform]);
+
   // 상태 관리
   const [state, setState] = useState<InfiniteScrollState>({
     page: 1,
@@ -59,9 +75,10 @@ export function useInfiniteScroll<T>(options: UseInfiniteScrollOptions<T>) {
       const data: BaseResponse<T> = await response.json();
 
       if (data.success) {
-        // 데이터 변환 적용
-        const transformedData = transform 
-          ? data.data.map(transform)
+        // 데이터 변환 적용 — read latest transform via ref so fetchData stays stable
+        const t = transformRef.current;
+        const transformedData = t
+          ? data.data.map(t)
           : data.data;
 
         setItems(prev => reset ? transformedData : [...prev, ...transformedData]);
@@ -79,24 +96,23 @@ export function useInfiniteScroll<T>(options: UseInfiniteScrollOptions<T>) {
           setStatistics((data as any).statistics);
         }
 
-        onSuccess?.(data);
+        onSuccessRef.current?.(data);
       } else {
         throw new Error(data.error || '데이터 조회에 실패했습니다.');
       }
     } catch (err) {
-      // AbortError는 무시
       if (err instanceof Error && err.name === 'AbortError') {
         return;
       }
-      
+
       const errorMessage = err instanceof Error ? err.message : '알 수 없는 오류가 발생했습니다.';
       setState(prev => ({
         ...prev,
         error: errorMessage,
         isInitialLoad: false
       }));
-      
-      onError?.(errorMessage);
+
+      onErrorRef.current?.(errorMessage);
     } finally {
       setState(prev => ({
         ...prev,
@@ -104,7 +120,7 @@ export function useInfiniteScroll<T>(options: UseInfiniteScrollOptions<T>) {
         isLoadingMore: false
       }));
     }
-  }, [apiEndpoint, limit, transform, onSuccess, onError]);
+  }, [apiEndpoint, limit]);
 
   // 재시도 함수
   const retry = useCallback(() => {


### PR DESCRIPTION
## Summary
4개 frontend 안정성 이슈 한 PR로:

## Major F1 — QuillBasicEditor 메모리 누수
- unmount 시 Quill 인스턴스/리스너 미파괴 → leak 누적

## Major F2 — NotificationContext 타이머 누수
- setTimeout cleanup 누락, deprecated substr 사용
- timersRef Map + crypto.randomUUID()로 정리

## Major F3 — CommentList refetch 누락
- forceUpdate만으로는 server prop이 갱신 안 됨
- router.refresh()로 server data 재요청

## Major F4 — useInfiniteScroll stale closure
- 콜백/transform을 ref로 안정화 → fetchData identity 유지
- IntersectionObserver thrash 차단

## Test plan
- [x] npm run build 성공
- [ ] Staging에서 community editor 진입/이탈 반복 → memory profiler에서 Quill leak 0
- [ ] Staging에서 댓글 작성 → 실시간 반영
- [ ] Staging에서 mypage 무한 스크롤 부드럽게 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)