### PR TITLE
fix(web): vote detail hydration mismatch + sentry noise 필터링

### DIFF
--- a/.sentryclirc
+++ b/.sentryclirc
@@ -2,5 +2,5 @@
 token=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
 
 [defaults]
-org=picnic-global
+org=icon-casting
 project=picnic-web

--- a/app/[lang]/(main)/vote/[id]/page.tsx
+++ b/app/[lang]/(main)/vote/[id]/page.tsx
@@ -3,6 +3,7 @@ import VoteDetailFetcher from '@/components/server/vote/VoteDetailFetcher';
 import VoteDetailSkeleton from '@/components/server/VoteDetailSkeleton';
 import { ErrorBoundary } from 'react-error-boundary';
 import { VoteErrorFallback } from '@/components/client/vote/common/VoteErrorFallback';
+import { settings, type Language } from '@/config/settings';
 
 interface VoteDetailPageProps {
   params: Promise<{
@@ -12,13 +13,16 @@ interface VoteDetailPageProps {
 }
 
 export default async function VoteDetailPage(props: VoteDetailPageProps) {
-  const { id } = await props.params;
+  const { id, lang } = await props.params;
+  const safeLang: Language = (settings.languages.supported as readonly string[]).includes(lang)
+    ? (lang as Language)
+    : settings.languages.default;
 
   return (
     <div className="container mx-auto px-4 py-8">
       <ErrorBoundary FallbackComponent={VoteErrorFallback}>
         <Suspense fallback={<VoteDetailSkeleton />}>
-          <VoteDetailFetcher voteId={id} />
+          <VoteDetailFetcher voteId={id} lang={safeLang} />
         </Suspense>
       </ErrorBoundary>
     </div>

--- a/components/client/vote/VoteDetail/VoteDetail.tsx
+++ b/components/client/vote/VoteDetail/VoteDetail.tsx
@@ -2,9 +2,10 @@
 
 import React, { useEffect, useRef } from 'react';
 import VoteDetailPresenter from '@/components/client/vote/detail/VoteDetailPresenter';
+import type { Language } from '@/config/settings';
 
 // 이제 voteData는 항상 존재한다고 가정하고, 로딩 상태는 상위 Suspense에서 처리합니다.
-const VoteDetail = ({ voteData }: { voteData: any }) => {
+const VoteDetail = ({ voteData, lang }: { voteData: any; lang: Language }) => {
   const { vote, voteItems, rewards, user, userVotes } = voteData;
 
   // 상태 전환(예정→진행, 진행→마감) 시점에 페이지 자동 새로고침
@@ -64,6 +65,7 @@ const VoteDetail = ({ voteData }: { voteData: any }) => {
       vote={vote}
       initialItems={voteItems}
       rewards={rewards}
+      lang={lang}
     />
   );
 };

--- a/components/client/vote/detail/useVoteDetail.ts
+++ b/components/client/vote/detail/useVoteDetail.ts
@@ -22,8 +22,15 @@ export function useVoteDetail({
   enableRealtime = true,
   pollingInterval = 1000,
   maxRetries = 3,
+  lang,
 }: VoteDetailPresenterProps) {
-  const { currentLanguage } = useLanguageStore();
+  const storeLanguage = useLanguageStore((s) => s.currentLanguage);
+  // SSR 과 client first-render 일치 보장: mount 전까지는 URL lang prop 사용.
+  // zustand persist 가 localStorage 값으로 hydrate 하면 SSR(default 'en')과 달라
+  // i18n 텍스트 (vote.title 등) 가 hydration mismatch 를 일으킴.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+  const currentLanguage = mounted ? storeLanguage : lang;
   const { withAuth } = useRequireAuth({
     customLoginMessage: {
       title: '투표하려면 로그인이 필요합니다',
@@ -208,6 +215,8 @@ export function useVoteDetail({
     if (!vote.start_at || !vote.stop_at) return '';
     const startDate = new Date(vote.start_at);
     const endDate = new Date(vote.stop_at);
+    // timeZone 을 명시하지 않으면 SSR(서버 TZ, 보통 UTC) vs CSR(사용자 로컬) 결과가
+    // 달라져 hydration mismatch 가 발생. K-pop 투표 마감 기준은 KST.
     const formatDate = (date: Date) =>
       date.toLocaleDateString('ko-KR', {
         year: 'numeric',
@@ -215,6 +224,7 @@ export function useVoteDetail({
         day: 'numeric',
         hour: '2-digit',
         minute: '2-digit',
+        timeZone: 'Asia/Seoul',
       });
     return `${formatDate(startDate)} ~ ${formatDate(endDate)}`;
   };

--- a/components/client/vote/detail/vote-detail-types.ts
+++ b/components/client/vote/detail/vote-detail-types.ts
@@ -60,4 +60,5 @@ export interface VoteDetailPresenterProps {
   enableRealtime?: boolean;
   pollingInterval?: number;
   maxRetries?: number;
+  lang: import('@/config/settings').Language;
 }

--- a/components/server/vote/VoteDetailFetcher.tsx
+++ b/components/server/vote/VoteDetailFetcher.tsx
@@ -4,13 +4,15 @@ import { notFound } from 'next/navigation';
 import { Vote, VoteItem, Reward } from '@/types/interfaces';
 import VoteDetailPresenter from '@/components/client/vote/detail/VoteDetailPresenter';
 import { getVoteById, getVoteItems, getVoteRewards } from '@/utils/api/queries';
+import type { Language } from '@/config/settings';
 
 export interface VoteDetailFetcherProps {
   voteId: string;
+  lang: Language;
   className?: string;
 }
 
-export default async function VoteDetailFetcher({ voteId, className }: VoteDetailFetcherProps) {
+export default async function VoteDetailFetcher({ voteId, lang, className }: VoteDetailFetcherProps) {
   const numericVoteId = parseInt(voteId, 10);
 
   if (isNaN(numericVoteId)) {
@@ -44,6 +46,7 @@ export default async function VoteDetailFetcher({ voteId, className }: VoteDetai
         enableRealtime={false}
         pollingInterval={1000}
         maxRetries={3}
+        lang={lang}
       />
     );
   } catch (error) {

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -55,6 +55,23 @@ if (SENTRY_DSN) {
         if (error?.value?.includes('hydration') && process.env.NODE_ENV === 'development') {
           return null;
         }
+        // Drop errors originating from third-party ad SDK frames
+        // (Google AdSense / DoubleClick / Twitter in-app webview injected globals).
+        // 우리 코드와 무관하며 disposed iframe race / 외부 전역 변수 미정의가 대다수.
+        const frames = error?.stacktrace?.frames ?? [];
+        const isThirdPartyAd = frames.some((f) => {
+          const fn = f.filename ?? '';
+          return (
+            fn.includes('/pagead/') ||
+            fn.includes('googlesyndication.com') ||
+            fn.includes('googletagservices.com') ||
+            fn.includes('doubleclick.net') ||
+            fn.includes('adsbygoogle')
+          );
+        });
+        if (isThirdPartyAd) {
+          return null;
+        }
       }
       return event;
     },
@@ -81,6 +98,17 @@ if (SENTRY_DSN) {
       // Ignore Next.js hydration errors in development
       'Hydration failed',
       'There was an error while hydrating',
+      // 외부 SDK / 인앱 브라우저 주입 변수 (Twitter, Facebook 등 in-app webview)
+      "Can't find variable: CONFIG",
+      'CONFIG is not defined',
+      // Google AdSense iframe disposal race (우리가 제어 불가)
+      'Accessing domItems after disposal',
+      'adsbygoogle.push() error',
+      // 사용자가 페이지 이탈/요청 취소 시 발생, 정상 흐름
+      'AbortError',
+      'The user aborted a request',
+      // Supabase realtime 채널 정상 종료
+      'Connection closed',
     ],
     maxBreadcrumbs: 30,
   });


### PR DESCRIPTION
## Summary

Sentry **PICNIC-WEB-5C Hydration Error** (24h 안에 154 events / 54 users) 차단 + 광고 SDK / 인앱브라우저 노이즈 7건 필터링.

### P0 — Hydration Error fix (`/[lang]/vote/[id]`)

원인 두 가지:
- `useLanguageStore` (zustand `persist`) 의 `currentLanguage` 가 **SSR 기본값 `'en'`** vs **CSR localStorage 복원값**으로 갈려 `vote.title` 등 i18n 텍스트가 SSR/CSR 다른 문자열로 hydrate.
- `formatVotePeriod` 의 `toLocaleDateString` 가 `timeZone` 미지정이라 서버 TZ(UTC) vs 클라이언트 TZ 결과가 달라짐.

Fix:
- `vote/[id]/page.tsx → VoteDetailFetcher → VoteDetailPresenter` 로 URL `[lang]` segment 를 명시적 prop 으로 drilling
- `useVoteDetail` 에 `mounted` 가드 — mount 전까지 prop `lang`, 이후 store 값 사용 (첫 render 가 SSR 결과와 일치)
- `formatVotePeriod` 에 `timeZone: 'Asia/Seoul'` 명시 (K-pop 투표 기준)

### P1 + P2 — Sentry 노이즈 필터 (`instrumentation-client.ts`)

- `beforeSend` 가 stack 에 `pagead/`, `googlesyndication`, `doubleclick`, `adsbygoogle` 포함된 이벤트 drop
- `ignoreErrors` 추가: \`Can't find variable: CONFIG\`, \`Accessing domItems after disposal\`, \`adsbygoogle.push() error\`, \`AbortError\`, \`Connection closed\`

대상 차단 이슈: PICNIC-WEB-5F/5G (CONFIG), 5H/5J (domItems), 5K (adsbygoogle), 5M (AbortError), 5E (Connection closed) — 모두 외부 SDK 또는 인앱브라우저(Twitter) 환경 한정 노이즈.

### 기타

- `.sentryclirc` org 정정: `picnic-global` → `icon-casting` (잘못된 슬러그라 \`sentry-cli issues list\` 가 403 으로 거부되던 문제 해결)

## Test plan

- [ ] Vercel Preview URL 에서 `/en/vote/231`, `/ko/vote/231`, `/ja/vote/231` 로 진입 — 콘솔에 hydration warning/error 없는지
- [ ] 다른 언어로 한 번 본 뒤 같은 페이지 다시 들어가도 (zustand persist 살아있어도) hydration error 안 나는지
- [ ] 투표 마감 시간 표시가 KST 로 일관되게 보이는지
- [ ] 머지 후 24h 동안 Sentry PICNIC-WEB-5C 신규 이벤트 0 건인지 확인 (\`sentry-cli issues list --org icon-casting --project picnic-web --query 'is:unresolved age:-24h'\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)