### PR TITLE
fix(web): useLanguageStore SSR/CSR hydration 근본 안정화

### DIFF
--- a/components/providers/LanguageSyncProvider.tsx
+++ b/components/providers/LanguageSyncProvider.tsx
@@ -206,9 +206,19 @@ const LanguageSyncProviderComponent = memo(function LanguageSyncProviderInternal
   }, [mounted, isHydrated, initialLanguage, currentLanguage, setCurrentLang]);
 
   // 클라이언트 hydration 처리
+  // store 는 skipHydration: true 라 import-time 에 persist 가 적용되지 않는다.
+  // mount 직후 rehydrate 를 명시적으로 호출해 localStorage 값을 store 에 반영한다.
+  // (이 시점은 첫 hydration render 가 끝난 직후라 SSR/CSR mismatch 가 발생하지 않음.)
   useEffect(() => {
     if (mounted && !isHydrated) {
-      setHydrated(true);
+      const rehydrate = (useLanguageStore as unknown as {
+        persist?: { rehydrate: () => void | Promise<void> };
+      }).persist?.rehydrate;
+      if (typeof rehydrate === 'function') {
+        Promise.resolve(rehydrate()).finally(() => setHydrated(true));
+      } else {
+        setHydrated(true);
+      }
     }
   }, [mounted, isHydrated, setHydrated]);
 

--- a/stores/languageStore.ts
+++ b/stores/languageStore.ts
@@ -36,11 +36,11 @@ const getCurrentLanguageFromPath = (): Language => {
   return settings.languages.default;
 };
 
-// 초기 언어 설정은 항상 URL 경로에서 가져옴 (클라이언트에서만)
-const initialLanguage: Language = (() => {
-  if (typeof window === "undefined") return settings.languages.default;
-  return getCurrentLanguageFromPath();
-})();
+// 초기 언어는 항상 default 로 고정한다. SSR 과 CSR 의 module-evaluation 결과가
+// 같아야 첫 render 시 hydration mismatch 가 안 일어남. URL/localStorage 기반
+// 실제 언어 동기화는 mount 후 LanguageSyncProvider 가 처리한다 (skipHydration
+// + persist.rehydrate + setCurrentLang).
+const initialLanguage: Language = settings.languages.default;
 
 interface LanguageState {
   currentLanguage: Language;
@@ -321,6 +321,10 @@ export const useLanguageStore = create<LanguageState>()(
     }),
     {
       name: "language-storage",
+      // import-time 자동 hydrate 를 막아 SSR(default) 과 CSR 첫 render 가
+      // 동일한 default 값으로 mount 되도록 한다. 명시적 rehydrate 는
+      // LanguageSyncProvider 가 mount 후 호출.
+      skipHydration: true,
       partialize: (state) => ({
         currentLanguage: state.currentLanguage,
       }),


### PR DESCRIPTION
## Summary

PR #11 은 \`vote/[id]\` 만 mounted 가드로 잡았지만 새 release 에서 mypage/login/vote-list/vote/[id] 모두에서 Hydration Error (PICNIC-WEB-5C) 가 계속 잡혔다. 근본 원인은 \`useLanguageStore\` 자체:

1. \`initialLanguage\` IIFE 가 CSR 에서 \`getCurrentLanguageFromPath()\` 로 URL lang 평가 → SSR(default) vs CSR module-eval 다름
2. zustand \`persist\` 가 import-time 즉시 localStorage 값으로 hydrate → 첫 render currentLanguage 가 SSR 와 다름

## Fix

- \`initialLanguage = settings.languages.default\` 고정 (SSR/CSR 동일)
- persist 에 \`skipHydration: true\` → import-time auto-hydrate 차단
- LanguageSyncProvider 가 mount 후 명시적 \`persist.rehydrate()\` → 첫 render 종료 후 localStorage / URL 값 반영

## UX trade-off

SSR HTML 이 항상 default 'en' 로 렌더 → ko/ja 등 사용자에게 1프레임 영어 깜빡임 가능. 진짜 lang-aware SSR 은 별도 prop drilling 작업 필요. 이 PR 은 hydration error 0 이 목표.

## Test plan

- [ ] Vercel Preview 에서 \`/ko/vote/231\`, \`/ko/mypage\`, \`/ja/vote\`, \`/en/login\` 접속 — 콘솔에 hydration warning/error 0
- [ ] localStorage 에 'ko' 가 남은 상태에서 \`/en/vote\` 접속 후 다시 \`/ko/vote\` — 깜빡임만 있고 에러 없는지
- [ ] 머지 후 release 에서 PICNIC-WEB-5C 신규 이벤트 0
- [ ] mypage/login/vote-list 의 다국어 텍스트가 mount 후 정상 표시되는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)