### PR TITLE
fix(web): vote toLocaleString locale 명시 (hydration)

### DIFF
--- a/components/client/vote/detail/VoteDetailPresenter.tsx
+++ b/components/client/vote/detail/VoteDetailPresenter.tsx
@@ -73,7 +73,7 @@ export function VoteDetailPresenter(props: VoteDetailPresenterProps) {
               <div className='flex flex-col sm:flex-row sm:items-center gap-2 text-sm text-gray-600 mb-2'>
                 <span>📅 {formatVotePeriod()}</span>
                 <span className="hidden sm:inline">•</span>
-                <span>👥 총 {voteItems.reduce((sum, item) => sum + (item.vote_total || 0), 0).toLocaleString()} 표</span>
+                <span>👥 총 {voteItems.reduce((sum, item) => sum + (item.vote_total || 0), 0).toLocaleString('en-US')} 표</span>
               </div>
               <div className="flex items-center justify-between">
                 {renderTimer()}
@@ -143,7 +143,7 @@ export function VoteDetailPresenter(props: VoteDetailPresenterProps) {
                       )}
                       <div className='space-y-0.5'>
                         <p className='text-xs sm:text-sm font-bold bg-gradient-to-r from-blue-600 to-purple-600 bg-clip-text text-transparent'>
-                          {(item.vote_total || 0).toLocaleString()}<span className='text-xs text-gray-500 ml-0.5'> 표</span>
+                          {(item.vote_total || 0).toLocaleString('en-US')}<span className='text-xs text-gray-500 ml-0.5'> 표</span>
                         </p>
                         {item.rank && (
                           <div className='flex items-center justify-center gap-0.5'>

--- a/components/client/vote/list/VoteItem.tsx
+++ b/components/client/vote/list/VoteItem.tsx
@@ -175,7 +175,7 @@ export function VoteItem({
         {/* 투표수 (표시 옵션이 활성화된 경우) */}
         {showVoteCount && isMounted && (
           <div className={`${styles.votes} text-primary`}>
-            {voteCount.toLocaleString()} 표
+            {voteCount.toLocaleString('en-US')} 표
           </div>
         )}
       </div>

--- a/components/client/vote/list/VoteResults.tsx
+++ b/components/client/vote/list/VoteResults.tsx
@@ -148,7 +148,7 @@ export function VoteResults({
         <h2 className="text-xl font-bold text-gray-900 mb-2">{title}</h2>
         <div className="flex items-center justify-between">
           <p className="text-sm text-gray-600">
-            총 {sortedResults.reduce((sum, item) => sum + item.voteCount, 0).toLocaleString()}표
+            총 {sortedResults.reduce((sum, item) => sum + item.voteCount, 0).toLocaleString('en-US')}표
           </p>
           {useStore && results.lastUpdateTime && (
             <p className="text-xs text-gray-400">
@@ -225,7 +225,7 @@ export function VoteResults({
               {/* 투표 결과 */}
               <div className="text-right flex-shrink-0">
                 <div className="text-lg font-bold text-gray-900">
-                  {item.voteCount.toLocaleString()}표
+                  {item.voteCount.toLocaleString('en-US')}표
                 </div>
                 {showPercentage && (
                   <div className="text-sm text-primary font-medium">

--- a/components/client/vote/list/VoteSubmit.tsx
+++ b/components/client/vote/list/VoteSubmit.tsx
@@ -228,7 +228,7 @@ export function VoteSubmit({
                 )}
                 {showVoteCount && (
                   <p className="text-sm font-bold text-primary">
-                    {voteCount.toLocaleString()} 표
+                    {voteCount.toLocaleString('en-US')} 표
                   </p>
                 )}
               </div>


### PR DESCRIPTION
## Summary

PR #12 (root fix) 후에도 vote/[id] 페이지에서 hydration error 가 시간당 1~3건 누적 (Mobile Safari/Samsung Internet/Edge 등 환경 다양). 원인은 \`toLocaleString()\` (locale 미지정).

- 서버: Node.js default \`en-US\` → \`1,000\`
- 클라이언트: 사용자 OS locale → \`1.000\` (de-DE) / \`1 000\` (fr-FR / sv-SE) 등
- 천단위 구분자 차이 → 텍스트 노드 mismatch

## Fix

전부 \`toLocaleString('en-US')\` 명시:
- VoteDetailPresenter (vote/[id] 직접): 총 표 수, 각 후보자 표 수
- VoteResults: 합계, 각 행
- VoteItem, VoteSubmit: 카드/제출

이미 \`'ko-KR'\` 명시된 곳 (VoteList/Ongoing/Completed/RankingView) 은 그대로.

## Test plan

- [ ] Vercel Preview 에서 OS locale 을 de-DE 등으로 두고 \`/ko/vote/231\` 접속 → 콘솔 hydration warning 없음
- [ ] 머지 후 release 에서 PICNIC-WEB-5C 신규 0 유지
- [ ] vote 표 수 표시가 모든 환경에서 \`1,234\` 형식 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)