### PR TITLE
feat(web): 인앱 브라우저 노이즈 차단 + Twitter/FB/IG/Line/NAVER 외부 브라우저 유도

### DIFF
--- a/app/[lang]/open-in-browser/page.tsx
+++ b/app/[lang]/open-in-browser/page.tsx
@@ -1,45 +1,149 @@
 import type { Metadata } from 'next';
+import { headers } from 'next/headers';
 import OpenClient from './OpenClient';
 
+const L = {
+  ko: {
+    title: '외부 브라우저로 열기',
+    desc: '인앱 브라우저에서는 로그인/결제 등 일부 기능이 제한됩니다. 아래 안내에 따라 외부 브라우저에서 열어주세요.',
+    target: '목표 페이지',
+    androidOpenChrome: '크롬으로 열기',
+    androidInstallChrome: '크롬 설치/업데이트',
+    iosTitle: 'Safari 에서 열기',
+    iosStep1: '1. 화면 우측 상단의 ⋯ (더보기) 또는 화살표(⤴) 아이콘을 누르세요.',
+    iosStep2: '2. 메뉴에서 "Safari 에서 열기" / "기본 브라우저에서 열기" 를 선택하세요.',
+    iosCopy: '링크 복사',
+    iosCopyHint: '메뉴가 보이지 않으면 링크를 복사해 Safari 에 붙여넣기 하세요.',
+  },
+  en: {
+    title: 'Open in your browser',
+    desc: 'In-app browsers limit features like login and payments. Please open this page in an external browser using the steps below.',
+    target: 'Target page',
+    androidOpenChrome: 'Open in Chrome',
+    androidInstallChrome: 'Install/Update Chrome',
+    iosTitle: 'Open in Safari',
+    iosStep1: '1. Tap the ⋯ (more) or arrow (⤴) icon at the top of the screen.',
+    iosStep2: '2. Choose "Open in Safari" or "Open in default browser".',
+    iosCopy: 'Copy link',
+    iosCopyHint: 'If the menu is not visible, copy the link and paste it into Safari.',
+  },
+} as const;
+
+type Lang = keyof typeof L;
+
+function pickLang(raw: string): Lang {
+  return raw === 'ko' ? 'ko' : 'en';
+}
+
 export const metadata: Metadata = {
-  title: '외부 브라우저로 열기',
+  title: 'Open in your browser',
+  robots: { index: false, follow: false },
 };
 
 type Props = {
+  params: Promise<{ lang: string }>;
   searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
 };
 
-export default async function OpenInBrowserPage({ searchParams }: Props) {
+export default async function OpenInBrowserPage({ params, searchParams }: Props) {
+  const { lang: rawLang } = await params;
+  const lang = pickLang(rawLang);
+  const t = L[lang];
+
   const sp = (await searchParams) || {};
-  const rawReturn = (typeof sp?.returnTo === 'string' ? sp?.returnTo : Array.isArray(sp?.returnTo) ? sp?.returnTo[0] : undefined) || '/';
+  const rawReturn =
+    (typeof sp?.returnTo === 'string'
+      ? sp?.returnTo
+      : Array.isArray(sp?.returnTo)
+        ? sp?.returnTo[0]
+        : undefined) || '/';
   const safeReturn = rawReturn.startsWith('/') ? rawReturn : `/${rawReturn}`;
   const host = 'www.picnic.fan';
   const httpsBase = `https://${host}`;
   const fallbackUrl = `${httpsBase}${safeReturn}`;
+
+  // OS detection (server-side from UA). 정확하지 않을 수 있어 양쪽 안내 둘 다 표시되도록 fallback.
+  const ua = (await headers()).get('user-agent') || '';
+  const isIOS = /iPhone|iPad|iPod/i.test(ua);
+  const isAndroid = /Android/i.test(ua);
+  const showAndroid = isAndroid || (!isIOS && !isAndroid);
+  const showIOS = isIOS || (!isIOS && !isAndroid);
+
   const intentHref = `intent://${host}${safeReturn}#Intent;scheme=https;package=com.android.chrome;S.browser_fallback_url=${encodeURIComponent(fallbackUrl)};end`;
-  const chromeMarket = 'market://details?id=com.android.chrome';
   const chromeMarketHttp = 'https://play.google.com/store/apps/details?id=com.android.chrome';
 
   return (
-    <div style={{ minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '24px', background: '#ffffff', color: '#111' }}>
+    <div
+      style={{
+        minHeight: '100vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '24px',
+        background: '#ffffff',
+        color: '#111',
+      }}
+    >
       <div style={{ maxWidth: 520, width: '100%', textAlign: 'center' }}>
         <OpenClient />
-        <h1 style={{ fontSize: 18, fontWeight: 600, marginBottom: 12 }}>외부 브라우저로 열기</h1>
-        <p style={{ color: '#4b5563', marginBottom: 20, lineHeight: 1.5 }}>
-          카카오톡 인앱 브라우저에서는 구글 로그인이 제한됩니다. 아래 버튼을 눌러 크롬에서 열어주세요.
+        <h1 style={{ fontSize: 18, fontWeight: 600, marginBottom: 12 }}>{t.title}</h1>
+        <p style={{ color: '#4b5563', marginBottom: 20, lineHeight: 1.5 }}>{t.desc}</p>
+        <p style={{ marginBottom: 16, fontSize: 12, color: '#6b7280', wordBreak: 'break-all' }}>
+          {t.target}: {fallbackUrl}
         </p>
-        <p style={{ marginBottom: 16, fontSize: 12, color: '#6b7280', wordBreak: 'break-all' }}>목표 페이지: {fallbackUrl}</p>
-        <div style={{ display: 'flex', gap: 8, justifyContent: 'center' }}>
-          <a href={intentHref} style={{ padding: '10px 16px', borderRadius: 8, background: '#2563eb', color: '#fff', textDecoration: 'none' }}>
-            크롬으로 열기
-          </a>
-          <a href={chromeMarketHttp} style={{ padding: '10px 16px', borderRadius: 8, background: '#e5e7eb', color: '#111827', textDecoration: 'none' }}>
-            크롬 설치/업데이트
-          </a>
-        </div>
+
+        {showAndroid && (
+          <div style={{ marginBottom: showIOS ? 24 : 0 }}>
+            <div style={{ display: 'flex', gap: 8, justifyContent: 'center', flexWrap: 'wrap' }}>
+              <a
+                href={intentHref}
+                style={{
+                  padding: '10px 16px',
+                  borderRadius: 8,
+                  background: '#2563eb',
+                  color: '#fff',
+                  textDecoration: 'none',
+                }}
+              >
+                {t.androidOpenChrome}
+              </a>
+              <a
+                href={chromeMarketHttp}
+                style={{
+                  padding: '10px 16px',
+                  borderRadius: 8,
+                  background: '#e5e7eb',
+                  color: '#111827',
+                  textDecoration: 'none',
+                }}
+              >
+                {t.androidInstallChrome}
+              </a>
+            </div>
+          </div>
+        )}
+
+        {showIOS && (
+          <div
+            style={{
+              borderTop: showAndroid ? '1px solid #e5e7eb' : 'none',
+              paddingTop: showAndroid ? 20 : 0,
+              textAlign: 'left',
+            }}
+          >
+            <h2 style={{ fontSize: 15, fontWeight: 600, marginBottom: 10, textAlign: 'center' }}>
+              {t.iosTitle}
+            </h2>
+            <p style={{ color: '#374151', fontSize: 14, lineHeight: 1.6, marginBottom: 6 }}>
+              {t.iosStep1}
+            </p>
+            <p style={{ color: '#374151', fontSize: 14, lineHeight: 1.6, marginBottom: 16 }}>
+              {t.iosStep2}
+            </p>
+            <p style={{ color: '#6b7280', fontSize: 12, lineHeight: 1.6 }}>{t.iosCopyHint}</p>
+          </div>
+        )}
       </div>
     </div>
   );
 }
-
-

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -73,6 +73,23 @@ if (SENTRY_DSN) {
           return null;
         }
       }
+      // 인앱 브라우저 (Twitter/X, Facebook, Instagram, KakaoTalk, Line, NAVER 등) 의
+      // hydration / replay_hydration_error 는 외부에서 DOM 을 mutate 하기 때문에
+      // 우리 코드로 100% 제거 불가능. 노이즈 차단.
+      const isHydrationError =
+        event.exception?.values?.[0]?.value?.toLowerCase().includes('hydrat') ||
+        (typeof event.message === 'string' && event.message.toLowerCase().includes('hydrat')) ||
+        event.tags?.['issue.type'] === 'replay_hydration_error';
+      if (isHydrationError) {
+        const ua = (event.request?.headers as Record<string, string> | undefined)?.['user-agent'] ?? '';
+        const browserName = (event.contexts?.browser?.name as string | undefined) ?? '';
+        const isInAppBrowser =
+          /KAKAOTALK|FBAV|FBAN|FB_IAB|Instagram|Twitter|TwitterAndroid|Line\/|NAVER\(inapp/i.test(ua) ||
+          /Twitter|Facebook|Instagram|KakaoTalk|Line|NAVER/i.test(browserName);
+        if (isInAppBrowser) {
+          return null;
+        }
+      }
       return event;
     },
     // Breadcrumb filtering (drop noisy console/info logs)

--- a/middleware.ts
+++ b/middleware.ts
@@ -83,22 +83,35 @@ export async function middleware(req: NextRequest) {
   // Create a response that we can modify cookies on
   const res = NextResponse.next({ request: { headers: req.headers } });
 
-  // In-app browser (KakaoTalk on Android) hard redirect to open-in-browser interstitial
+  // 인앱 브라우저 (KakaoTalk, Twitter/X, Facebook, Instagram, Line, NAVER) hard redirect.
+  // 인앱은 DOM mutation, OAuth third-party cookie 차단, 결제 redirect 제약 등으로
+  // 핵심 기능이 자주 깨진다. /open-in-browser interstitial 로 외부 브라우저 유도.
   try {
     const ua = req.headers.get('user-agent') || '';
     const url = new URL(req.url);
     const pathname = url.pathname;
 
-    const isKakao = /KAKAOTALK/i.test(ua);
-    const isAndroid = /Android/i.test(ua);
+    // SNS 미리보기/검색엔진 봇은 redirect 하지 않는다 (OGP, 인덱싱 영향).
+    const isBot = /bot|crawler|spider|googlebot|bingbot|duckduckbot|yandexbot|baiduspider|facebookexternalhit|twitterbot|linkedinbot|slackbot|whatsapp|telegrambot|discordbot|kakaobot|naverbot|yeti/i.test(ua);
+
+    // 인앱 브라우저 식별. UA 패턴은 각 앱 공식 문서/실측 기준.
+    // - KakaoTalk: "KAKAOTALK"
+    // - Facebook: "FBAV", "FBAN", "FB_IAB" (in-app browser)
+    // - Instagram: "Instagram"
+    // - Twitter/X: "Twitter for iPhone/iPad", "TwitterAndroid", "Twitter Lite"
+    // - Line: "Line/"
+    // - NAVER: "NAVER(inapp" (네이버 앱)
+    const isInApp = !isBot && /KAKAOTALK|FBAV|FBAN|FB_IAB|Instagram|Twitter for|TwitterAndroid|Twitter Lite|Line\/|NAVER\(inapp/i.test(ua);
+
     const isAlreadyOpenPage = /\/open-in-browser(\/|$)/.test(pathname);
     const isApi = pathname.startsWith('/api/');
     // 정적 자산: Next 내부 정적 경로, 파비콘, 그리고 파일 확장자를 가진 퍼블릭 파일들(.txt, .xml, .json 등)
     const hasFileExtension = /\.[a-zA-Z0-9]+$/.test(pathname);
     const isStatic = pathname.startsWith('/_next') || pathname === '/favicon.ico' || hasFileExtension;
+    // OAuth callback 은 인앱에서도 통과시켜야 callback handler 가 동작
     const isAuthCallback = pathname.startsWith('/auth/callback');
 
-    if (isKakao && isAndroid && !isAlreadyOpenPage && !isApi && !isStatic) {
+    if (isInApp && !isAlreadyOpenPage && !isApi && !isStatic && !isAuthCallback) {
       const returnTo = `${pathname}${url.search}` || '/';
       const target = new URL(`/open-in-browser`, url.origin);
       target.searchParams.set('returnTo', returnTo);


### PR DESCRIPTION
## Summary

KakaoTalk Android 만 \`/open-in-browser\` 로 redirect 하던 흐름을 다른 인앱브라우저까지 확장하고, 인앱이 일으키는 hydration 노이즈를 Sentry 단에서 차단.

## Background

PR #12, #13 (root + locale fix) 후에도 vote/[id] 페이지에서 시간당 1건의 hydration error 가 잔존. Sentry 분석 결과 모두 **Twitter for iPhone (Mobile Safari 26 / iOS 26)** 환경. 인앱은 자체 광고 script 주입 + DOM mutation 으로 React 19 의 hydration 1:1 일치 보장을 깨므로, 우리 코드 수정만으로는 100% 해결 불가능. 게다가 같은 인앱 환경에서 OAuth (Apple/Google/Kakao) 와 결제 redirect 도 자주 실패함.

## Changes

### \`middleware.ts\` UA 패턴 확장
인앱 매칭 패턴: \`KAKAOTALK | FBAV | FBAN | FB_IAB | Instagram | Twitter for | TwitterAndroid | Twitter Lite | Line/ | NAVER(inapp\`. 검색엔진/SNS 봇 (twitterbot, facebookexternalhit, googlebot, bingbot, duckduckbot 등) 은 OGP/SEO 보호 위해 명시적 제외. \`/auth/callback\` 은 인앱이어도 통과 (callback handler 가 외부에서 다시 진입 못 함).

### \`/open-in-browser/page.tsx\` iOS/Android 분기 + 다국어
- iOS: \"Safari 우상단 ⋯ → Safari 에서 열기\" 텍스트 가이드 (현실적으로 iOS 는 강제 redirect 불가)
- Android: 기존 \`intent://\` Chrome scheme + Play 스토어 fallback
- ko/en 라벨 분기, \`/[lang]\` segment 기반 (다른 언어는 en 으로 fallback)
- \`robots: noindex\` 메타 추가

### \`instrumentation-client.ts\` 인앱 hydration 노이즈 필터
\`beforeSend\` 가 hydration 계열 이벤트 (\`replay_hydration_error\` 포함) 의 UA 또는 \`browser.name\` 이 인앱 패턴과 매칭되면 drop. 우리 코드로 잡을 수 없는 케이스의 노이즈를 차단해 진짜 hydration 회귀를 빠르게 감지할 수 있게 함.

## Test plan

- [ ] Vercel Preview 에서 \`User-Agent\` 헤더를 \`Mozilla/5.0 ... Twitter for iPhone\` 으로 두고 \`/en/vote/231\` 접속 → \`/open-in-browser\` 로 redirect 되는지
- [ ] 같은 UA + \`/auth/callback?...\` 으로 접속 → 통과하는지
- [ ] \`User-Agent: Twitterbot/1.0\` 으로 접속 → redirect 되지 않고 정상 페이지 받아 OGP 정상 노출
- [ ] iOS Safari 일반 접속 → 영향 없는지 (인앱 매칭 false)
- [ ] /open-in-browser 페이지가 ko/en 양쪽에서 정확한 라벨 노출
- [ ] 머지 후 release 에서 PICNIC-WEB-5C 신규 0 (인앱 케이스가 redirect 되어 hydrate 자체 안 일어남)

🤖 Generated with [Claude Code](https://claude.com/claude-code)