### PR TITLE
fix(web): AdSense vignette hydration race 차단 + Sentry 광고 필터

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -76,7 +76,10 @@ export default async function RootLayout({
           <ConsentAwareAdsense
             clientId="ca-pub-1539304887624918"
             delayUntilIdle={shouldDelayAds}
-            idleTimeout={shouldDelayAds ? 2200 : 1200}
+            // vote 라우트는 React hydration 종료를 충분히 보장하기 위해 5s 로 늘림.
+            // AdSense Auto ads / vignette 가 hydration 전에 DOM 을 mutate 하면
+            // PICNIC-WEB-5C (replay_hydration_error) 가 #google_vignette URL 로 발생.
+            idleTimeout={shouldDelayAds ? 5000 : 1200}
           />
         )}
         <div className="bg-white">

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -89,6 +89,20 @@ if (SENTRY_DSN) {
         if (isInAppBrowser) {
           return null;
         }
+        // Google AdSense Auto ads (특히 #google_vignette interstitial) 가 hydration
+        // 종료 전에 DOM 을 mutate 하면 우리 코드와 무관한 hydration mismatch 가
+        // 잡힌다. URL fragment / request URL 이 광고 단서면 drop.
+        const reqUrl =
+          (typeof event.request?.url === 'string' ? event.request.url : '') ||
+          (event.tags && (event.tags as Record<string, string>)['url']) ||
+          '';
+        if (
+          reqUrl.includes('#google_vignette') ||
+          reqUrl.includes('googlesyndication') ||
+          reqUrl.includes('googleadservices')
+        ) {
+          return null;
+        }
       }
       return event;
     },


### PR DESCRIPTION
## Summary

PR #17 빌드 (\`picnic-web@20260427.1713.001\`) 에서도 PICNIC-WEB-5C (Hydration Error) 가 시간당 ~1건 잔존. 5C latest events 의 URL fragment 분석 결과 \`#google_vignette\` 가 반복 등장 → Google AdSense Auto ads 가 React hydration 종료 전에 vignette interstitial 광고를 vote 페이지에 inject 하면서 DOM mutate, mismatch 유발.

## Fix

- \`app/layout.tsx\` 의 vote 라우트 \`idleTimeout\` **2200ms → 5000ms**. \`ConsentAwareAdsense\` 가 client mount 후 idle 콜백 시점에 AdSense script 를 주입하는데, 모바일/저속 환경에서 hydration 이 2.2s 보다 오래 걸리면 광고가 먼저 inject 되어 race. 5s 면 hydration 완료 보장 가능성 큼. vote 외 라우트는 1200ms 유지.
- \`instrumentation-client.ts\` 의 \`beforeSend\` 에 hydration 이벤트의 request URL 이 \`#google_vignette\` / \`googlesyndication\` / \`googleadservices\` 면 drop. AdSense 가 일으킨 mismatch 는 우리 코드 수정으로 100% 차단 불가능 → 노이즈 차단.

## UX trade-off

vote 페이지에서 광고 표시까지 5초 대기. 사용자 engagement 가 높은 페이지라 영향 미미. AdSense 콘솔에서 \`#google_vignette\` 자체를 비활성화하는 별도 작업도 권장 (수익/UX 균형).

## Test plan

- [ ] Vercel Preview 에서 \`/en/vote/225\` 진입 → 콘솔에 hydration warning 없는지, 광고가 5초 후 정상 표시되는지
- [ ] 머지 후 release 에서 PICNIC-WEB-5C 신규 0 추세
- [ ] Sentry 에 \`#google_vignette\` URL hydration 이벤트가 새로 안 들어오는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)