### PR TITLE
fix(web): vote framer-motion 컴포넌트 mount gate (5C 잔존 root cause)

### DIFF
--- a/components/client/vote/common/VoteRankCard.tsx
+++ b/components/client/vote/common/VoteRankCard.tsx
@@ -27,6 +27,13 @@ export function VoteRankCard({
   onVoteChange,
   enableMotionAnimations = true,
 }: VoteRankCardProps) {
+  // SSR / CSR first render 에서는 framer-motion 분기를 끈다. motion 컴포넌트는
+  // mount 시점에 inline style (transform / boxShadow / spring 값) 을 계산해
+  // SSR HTML 에 없는 attribute 를 추가하므로, 그 자체가 hydration mismatch 의
+  // 알려진 원인 (PICNIC-WEB-5C 의 vote/[id] + Podium 케이스). mount 후에만 motion 활성.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+  const motionEnabled = enableMotionAnimations && mounted;
   const { currentLanguage, t } = useLanguageStore();
   const { withAuth } = useRequireAuth({
     customLoginMessage: {
@@ -124,7 +131,7 @@ export function VoteRankCard({
   const sizeClasses = getFullWidthSize(rank);
 
   // 애니메이션이 비활성화된 경우 기본 렌더링
-  if (!enableMotionAnimations) {
+  if (!motionEnabled) {
     return (
       <div
         className={`relative flex flex-col justify-center items-center ${

--- a/components/ui/animations/RealtimeAnimations.tsx
+++ b/components/ui/animations/RealtimeAnimations.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { motion, useSpring, useTransform } from 'framer-motion';
 
 // 실시간 카운트 애니메이션
@@ -21,6 +21,13 @@ export function AnimatedCount({
   suffix = '',
   locale = 'en-US'
 }: AnimatedCountProps) {
+  // SSR / CSR first render 일치 보장을 위해 mount 전엔 plain span 으로
+  // 정적 숫자만 출력. mount 후에야 framer-motion spring 으로 transition.
+  // motion.span 의 initial/animate transform 과 useTransform display 가
+  // SSR HTML 에 없는 attribute 를 추가해 hydration mismatch 를 일으키므로.
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
   const springValue = useSpring(value, {
     duration: duration * 1000,
     bounce: 0.1
@@ -32,6 +39,16 @@ export function AnimatedCount({
   useEffect(() => {
     springValue.set(value);
   }, [springValue, value]);
+
+  if (!mounted) {
+    return (
+      <span className={className}>
+        {prefix}
+        {Math.floor(value).toLocaleString(locale)}
+        {suffix}
+      </span>
+    );
+  }
 
   return (
     <motion.span


### PR DESCRIPTION
## Summary

PR #18 빌드 (\`1713.001\`/\`0932.001\`) 에서도 PICNIC-WEB-5C 가 시간당 ~1건 잔존 (vote/225 페이지, Mobile + Desktop 광범위, \`#google_vignette\` 없음). Sentry Replay 영상 + 코드 분석 결과 framer-motion 두 컴포넌트가 root cause:

- **VoteRankCardAnimated** \`motion.div\` + \`layout\` + \`initial/animate\` 의 rank-conditional \`boxShadow\`
- **AnimatedCount** \`motion.span\` + \`useSpring\` + \`useTransform\` + \`key={value}\`

둘 다 mount 시 inline style (transform / boxShadow / spring 값) 을 SSR HTML 에 없는 형태로 추가 → React 19 hydration 1:1 일치 깨짐. 알려진 framer-motion SSR/CSR mismatch 패턴.

## Fix

- \`VoteRankCard\`: \`useState\` mounted gate 추가, \`motionEnabled = enableMotionAnimations && mounted\`. SSR + CSR first render 는 기존 정적 분기 사용, mount 후 framer-motion 분기 전환.
- \`AnimatedCount\`: mount 전엔 plain \`<span>{value.toLocaleString(locale)}</span>\`, mount 후 \`motion.span\` + spring transition 활성.

UX motion 모두 유지. 차이는 mount 후 1프레임의 미세한 transition 시작 지연뿐.

## Test plan

- [ ] Vercel Preview 에서 \`/ko/vote/225\` (Podium TOP3 표시 vote) 접속 → 콘솔 hydration warning 없음
- [ ] AnimatedCount 가 mount 후 spring 으로 부드럽게 변하는지
- [ ] Podium 카드 hover/click 시 motion 작동 (mount 후)
- [ ] 머지 후 release 에서 PICNIC-WEB-5C 신규 0 추세

🤖 Generated with [Claude Code](https://claude.com/claude-code)