### PR TITLE
fix(web): Sentry 필터에 window.location.href 추가 (vignette fragment 매칭)

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -91,15 +91,18 @@ if (SENTRY_DSN) {
         }
         // Google AdSense Auto ads (특히 #google_vignette interstitial) 가 hydration
         // 종료 전에 DOM 을 mutate 하면 우리 코드와 무관한 hydration mismatch 가
-        // 잡힌다. URL fragment / request URL 이 광고 단서면 drop.
-        const reqUrl =
-          (typeof event.request?.url === 'string' ? event.request.url : '') ||
-          (event.tags && (event.tags as Record<string, string>)['url']) ||
-          '';
+        // 잡힌다. event.request.url 은 HTTP 요청 URL 이라 fragment(#...) 가 빠지므로
+        // window.location.href 와 tags.url 까지 합쳐서 검사한다.
+        const reqUrl = typeof event.request?.url === 'string' ? event.request.url : '';
+        const tagUrl =
+          (event.tags && (event.tags as Record<string, string>)['url']) || '';
+        const winUrl = typeof window !== 'undefined' ? window.location.href : '';
+        const allUrls = `${reqUrl}|${tagUrl}|${winUrl}`;
         if (
-          reqUrl.includes('#google_vignette') ||
-          reqUrl.includes('googlesyndication') ||
-          reqUrl.includes('googleadservices')
+          allUrls.includes('#google_vignette') ||
+          allUrls.includes('googlesyndication') ||
+          allUrls.includes('googleadservices') ||
+          allUrls.includes('googleads')
         ) {
           return null;
         }


### PR DESCRIPTION
## Summary

PR #18 에 추가한 \`#google_vignette\` URL 필터가 PR #19 빌드 (\`1507.001\`) 의 5C 이벤트 \`2026-04-28T06:52 ko/vote/225#google_vignette\` 를 못 잡음. \`event.request.url\` 은 HTTP request URL 이라 fragment 가 빠지므로 매치 실패.

## Fix

\`window.location.href\` (fragment 포함) + \`event.tags.url\` + \`event.request.url\` 세 source 를 합쳐서 검사. AdSense 도메인에 \`googleads\` 도 추가.

🤖 Generated with [Claude Code](https://claude.com/claude-code)