### PR TITLE
fix(web): vote/[id] presenter CSR-only 전환 (Sentry PICNIC-WEB-5C)

### DIFF
--- a/components/client/vote/detail/VoteDetailClientOnly.tsx
+++ b/components/client/vote/detail/VoteDetailClientOnly.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import VoteDetailSkeleton from '@/components/server/VoteDetailSkeleton';
+import type { VoteDetailPresenterProps } from './vote-detail-types';
+
+// SSR 을 끄는 이유: 모바일 브라우저(UC/Vivo/번역기/광고차단기 등)가
+// SSR HTML 직후 client mount 사이에 DOM 을 변형하면 React 19 가
+// hydration mismatch 로 throw → Sentry PICNIC-WEB-5C 가 반복 발생.
+// 데이터 prefetch 는 server fetcher 가 그대로 처리하므로
+// Presenter 만 client-only 로 마운트해 mismatch 자체를 제거한다.
+const VoteDetailPresenter = dynamic(
+  () => import('./VoteDetailPresenter'),
+  { ssr: false, loading: () => <VoteDetailSkeleton /> },
+);
+
+export default function VoteDetailClientOnly(props: VoteDetailPresenterProps) {
+  return <VoteDetailPresenter {...props} />;
+}

--- a/components/server/vote/VoteDetailFetcher.tsx
+++ b/components/server/vote/VoteDetailFetcher.tsx
@@ -2,7 +2,7 @@ import 'server-only';
 import React from 'react';
 import { notFound } from 'next/navigation';
 import { Vote, VoteItem, Reward } from '@/types/interfaces';
-import VoteDetailPresenter from '@/components/client/vote/detail/VoteDetailPresenter';
+import VoteDetailClientOnly from '@/components/client/vote/detail/VoteDetailClientOnly';
 import { getVoteById, getVoteItems, getVoteRewards } from '@/utils/api/queries';
 import type { Language } from '@/config/settings';
 
@@ -38,7 +38,7 @@ export default async function VoteDetailFetcher({ voteId, lang, className }: Vot
     };
 
     return (
-      <VoteDetailPresenter
+      <VoteDetailClientOnly
         vote={vote as Vote}
         initialItems={(vote?.vote_item || []) as unknown as VoteItem[]}
         rewards={(rewards || []) as Reward[]}


### PR DESCRIPTION
## Summary
- UC/VivoBrowser 등 모바일 브라우저의 page injection 으로 SSR HTML 과 client tree 가 어긋나며 발생하던 [PICNIC-WEB-5C](https://icon-casting.sentry.io/issues/PICNIC-WEB-5C) (250 users / 530 events, regressed) 차단
- 메모리 패턴(mounted gate / `skipHydration` / TZ 명시 / URL lang prop) 은 모두 이미 적용됐으나 외부 inject 는 통제 불가 → Presenter 자체를 `dynamic({ssr:false})` 로 전환해 hydration 단계 제거
- 데이터 prefetch (`getVoteById/Items/Rewards`) 는 server `VoteDetailFetcher` 가 그대로 처리, RSC props 로 client 전달 → SEO/콘텐츠 prefetch 영향 미미

## 변경
- 신규 `components/client/vote/detail/VoteDetailClientOnly.tsx` — `'use client'` wrapper, `dynamic({ ssr:false, loading: VoteDetailSkeleton })`
- `components/server/vote/VoteDetailFetcher.tsx` — Presenter import 한 줄 교체

## Test plan
- [x] `tsc --noEmit` 통과 (exit 0)
- [x] dev server (`/id/vote/230`) HTTP 200, SSR HTML 에 `animate-pulse` 68개 / Presenter 콘텐츠 0
- [x] Playwright 콘솔 에러 0 (Sentry envelope 429 1건만, 페이지 무관)
- [x] 클라이언트 마운트 후 Top 3 podium / 20 vote items / useVotePolling (`안정적 폴링`) 정상 렌더
- [x] Indonesian nav 정상 (`Pemungutan suara`, `Bahasa Indonesia`)
- [ ] Vercel preview URL 에서 동일 검증
- [ ] 머지 후 PICNIC-WEB-5C resolve, 7-14일 모니터링

## 후속 (별도 PR)
- `[PICNIC-WEB-5N](https://icon-casting.sentry.io/issues/PICNIC-WEB-5N)` (`/rewards` removeChild null) 도 동일 패턴으로 처리 검토

🤖 Generated with [Claude Code](https://claude.com/claude-code)