### PR TITLE
fix(web): PayPal popup cross-origin URL polling 제거 (Sentry PICNIC-WEB-5D)

### DIFF
--- a/components/client/star-candy/usePaymentHandlers.ts
+++ b/components/client/star-candy/usePaymentHandlers.ts
@@ -174,25 +174,10 @@ export function usePaymentHandlers({
                 return;
               }
 
-              // Check popup URL for success/cancel indicators
-              try {
-                const currentUrl = paypalWindow?.location?.href;
-                if (currentUrl && currentUrl.includes('success')) {
-                  clearInterval(interval);
-                  paypalWindow?.close();
-
-                  // Capture the order
-                  const result = await payPalService.captureOrder(orderID);
-                  if (result.success) {
-                    alert(t('payment_success'));
-                    window.location.reload();
-                  } else {
-                    alert(t('payment_failed'));
-                  }
-                }
-              } catch (error) {
-                // Cross-origin restriction, continue polling
-              }
+              // popup 이 paypal.com 으로 redirect 된 뒤 location.href 를 읽으면
+              // SecurityError(cross-origin) 가 매 tick 마다 throw 되어 sentry 에
+              // 노이즈가 쌓인다. 결제 완료 detect 는 위의 closed→captureOrder
+              // 경로로 충분하므로 URL polling 은 제거.
             } catch (error) {
               console.error('Error polling payment status:', error);
             }


### PR DESCRIPTION
## Summary
- [PICNIC-WEB-5D](https://icon-casting.sentry.io/issues/PICNIC-WEB-5D) (`SecurityError: Blocked a frame with origin "https://www.picnic.fan" from accessing a cross-origin frame`) 의 root cause 제거
- \`/star-candy\` PayPal 결제 polling 에서 \`paypalWindow.location.href\` 를 cross-origin redirect 이후에도 매 tick 마다 읽으려고 시도 → SecurityError 가 try/catch 로 swallow 되지만 Sentry onerror 가 노이즈로 누적 (12 events / 1 user, Whale iOS)

## 변경
- \`components/client/star-candy/usePaymentHandlers.ts\` — popup URL polling 블록 삭제 (-19 / +4)

## 왜 안전한가
- 결제 완료 detect 는 같은 polling loop 의 \`paypalWindow.closed\` 분기 (line 161-174) 에서 \`captureOrder()\` 호출로 이미 처리됨
- URL polling 분기는 popup 이 cross-origin 으로 redirect 된 뒤엔 어차피 절대 매칭되지 않음 (try/catch 가 매번 swallow 하던 구조)
- 즉 기존 success path 는 closed 분기로 이미 동등하게 처리되고 있었고, URL polling 은 redundant + 안티-패턴

## Test plan
- [x] \`tsc --noEmit\` 통과
- [ ] Vercel preview URL 에서 \`/star-candy\` 진입 정상
- [ ] 머지 후 Sentry PICNIC-WEB-5D 모니터링 (1주일)

🤖 Generated with [Claude Code](https://claude.com/claude-code)