### PR TITLE
fix(web): AdSense/CMP cross-origin SecurityError 노이즈 차단 (Sentry 5D, 61)

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -72,6 +72,24 @@ if (SENTRY_DSN) {
         if (isThirdPartyAd) {
           return null;
         }
+        // AdSense Auto Ads / Funding Choices CMP 가 cross-origin iframe 에
+        // access 시도하면 stacktrace 에 우리 chunk 의 minified line 만 남고
+        // 광고 SDK filename 이 안 보여 위의 isThirdPartyAd 가 못 잡는다.
+        // 메시지 패턴으로 추가 차단.
+        //   - "Blocked a frame with origin ... cross-origin frame" (PICNIC-WEB-5D)
+        //   - "The request was denied." DOMException code 18 (PICNIC-WEB-61)
+        const errType = error?.type ?? '';
+        const errValue = error?.value ?? '';
+        const isCrossOriginSecurityError =
+          errType === 'SecurityError' &&
+          (
+            errValue.includes('cross-origin frame') ||
+            errValue.includes('Blocked a frame') ||
+            errValue === 'The request was denied.'
+          );
+        if (isCrossOriginSecurityError) {
+          return null;
+        }
       }
       // 인앱 브라우저 (Twitter/X, Facebook, Instagram, KakaoTalk, Line, NAVER 등) 의
       // hydration / replay_hydration_error 는 외부에서 DOM 을 mutate 하기 때문에


### PR DESCRIPTION
## Summary
- [PICNIC-WEB-5D](https://icon-casting.sentry.io/issues/PICNIC-WEB-5D) (1u/19ev, Whale iOS — regressed) 와 [PICNIC-WEB-61](https://icon-casting.sentry.io/issues/PICNIC-WEB-61) (2u/8ev, Chrome Mobile ID) 의 root cause 는 AdSense Auto Ads + Funding Choices CMP iframe 의 cross-origin frame access. PayPal/star-candy 결제 코드는 무관 (PR #22 머지 후에도 5D regress 한 게 증거).
- 5D breadcrumbs 에 \`fundingchoicesmessages.google.com\` XHR 4건 직후 SecurityError throw 가 확인됨.
- 기존 \`isThirdPartyAd\` filter 는 stacktrace frame filename 으로 광고 SDK 판별 — cross-origin throw 의 경우 우리 chunk 의 minified line 만 남아 SDK filename 이 stacktrace 에 안 보여 통과.

## 변경
- \`instrumentation-client.ts\` \`beforeSend\` 안에 메시지 패턴 기반 가드 추가 (+18 lines).
  - \`SecurityError: Blocked a frame ... cross-origin frame\` → drop
  - \`SecurityError: The request was denied.\` (DOMException code 18) → drop

## 안전성
- \`error.type === 'SecurityError'\` 일 때만 매칭 → 우리 코드의 SecurityError 가 다른 message 면 통과
- 매칭되는 메시지는 모두 cross-origin / DOM cookie 차단 등 환경/SDK 노이즈
- 진짜 우리 코드의 SecurityError 가 동일 메시지로 발생할 가능성은 매우 낮음 (cross-origin frame 접근은 우리 코드에 없음)

## Test plan
- [x] \`tsc --noEmit\` 통과
- [ ] Vercel preview deploy 정상
- [ ] 머지 후 5D / 61 Sentry 에서 \"Archive Forever\" 처리
- [ ] 7일 모니터링 — 5D / 61 동일 group 으로 신규 events 안 들어오는지 확인

## 참고
관련된 잔여 노이즈 issues 도 같이 Archive Forever 권장: 5N (rewards removeChild), 5V/5S (Yd login), 5W/5X (Vivo inject), 5Y (IndexedDB), 5R (Telegram postEvent), 5P (open-in-browser), 63 (RangeError open-in-browser), 60 (Firebase offline), 62 (Timeout vote).

🤖 Generated with [Claude Code](https://claude.com/claude-code)