### PR TITLE
fix(goong-hap): 아티스트 검색/선택에서 soft-deleted 제외

### DIFF
--- a/app/[lang]/(main)/goong-hap/new/useGoonghapForm.ts
+++ b/app/[lang]/(main)/goong-hap/new/useGoonghapForm.ts
@@ -47,10 +47,13 @@ export function useGoonghapForm() {
           try {
             const { data } = await supabase
               .from('artist_user_bookmark')
-              .select('artist:artist(id,name,image)')
+              .select('artist:artist(id,name,image,deleted_at)')
               .eq('user_id', user.id)
               .limit(50);
-            const mapped = (data || []).map((row: any) => row.artist).filter(Boolean);
+            // soft-deleted 아티스트는 '내 아티스트' 목록에서 제외
+            const mapped = (data || [])
+              .map((row: any) => row.artist)
+              .filter((a: any) => a && !a.deleted_at);
             setMyArtists(mapped);
           } catch {}
 
@@ -112,6 +115,7 @@ export function useGoonghapForm() {
       const { data, error } = await supabase
         .from('artist')
         .select('id,name,image')
+        .is('deleted_at', null) // soft-deleted 아티스트 제외
         .or(`name->>ko.ilike.%${q}%,name->>en.ilike.%${q}%,name->>ja.ilike.%${q}%`)
         .order('id', { ascending: true })
         .limit(20);
@@ -155,6 +159,7 @@ export function useGoonghapForm() {
           .from('artist')
           .select('id, birth_date, yy, mm, dd')
           .eq('id', selectedArtistId!)
+          .is('deleted_at', null) // soft-deleted 아티스트 선택 차단
           .single();
         if (artistErr) throw artistErr;
 


### PR DESCRIPTION
## 문제
앱의 아티스트 검색 버그(삭제된 아티스트 노출)와 **동일 클래스** 가 웹 궁합(goong-hap) 아티스트 기능에도 존재. 검색·선택 쿼리가 `deleted_at` 을 거르지 않음.

## 변경 (`useGoonghapForm.ts`)
- `handleSearchArtists`: 아티스트 검색에 `.is('deleted_at', null)`
- `createNewGoonghap`: 선택 아티스트 생일 조회에 필터 추가 → 삭제 아티스트 선택 차단
- "내 아티스트" 북마크 목록: 삭제 아티스트 제외

## 의도적으로 제외 (회귀 방지)
투표 결과/기록·보드 등 과거 조인 표시는 필터 미적용. 살아있는 `vote_item` 4,293개가 삭제된 아티스트를 참조 중이라 집계가 바뀜.

## 검증
`tsc --noEmit` 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)