### PR TITLE
feat(web): BETA 노출 강화 (풀폭 배너 + 헤더 태그) + 광고 쏠림 해결

### DIFF
--- a/components/layouts/ExclusiveOpenBadge.tsx
+++ b/components/layouts/ExclusiveOpenBadge.tsx
@@ -21,7 +21,7 @@ const ExclusiveOpenBadge: React.FC<ExclusiveOpenBadgeProps> = ({ className = '' 
 
     switch (currentLanguage) {
       case 'ko':
-        return '현재는 배타 오픈 기간입니다. 곧 정식 서비스를 제공할 예정입니다.';
+        return '현재는 베타 오픈 기간입니다. 곧 정식 서비스를 제공할 예정입니다.';
       case 'en':
         return 'Currently in exclusive open beta. Official service coming soon.';
       case 'ja':
@@ -38,9 +38,18 @@ const ExclusiveOpenBadge: React.FC<ExclusiveOpenBadgeProps> = ({ className = '' 
   };
 
   return (
-    <div className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800 ${className}`}>
-      <span className="mr-1">🎯</span>
-      {getExclusiveOpenText()}
+    <div
+      role="status"
+      className={`w-full bg-amber-400 text-amber-950 border-b border-amber-500 ${className}`}
+    >
+      <div className="container mx-auto flex items-center justify-center gap-2 px-3 py-1.5 text-center sm:py-2">
+        <span className="shrink-0 inline-flex items-center rounded bg-amber-950 px-1.5 py-0.5 text-[10px] font-extrabold uppercase tracking-wider text-amber-50 sm:text-xs">
+          Beta
+        </span>
+        <span className="text-xs font-semibold leading-snug sm:text-sm">
+          {getExclusiveOpenText()}
+        </span>
+      </div>
     </div>
   );
 };

--- a/components/layouts/Header.tsx
+++ b/components/layouts/Header.tsx
@@ -150,6 +150,9 @@ const Header: React.FC = () => {
             <NavigationLink href="/" className='flex items-center flex-shrink-0'>
               <Image src='/images/logo.webp' alt='logo' width={40} height={40} priority className='w-8 h-8 sm:w-10 sm:h-10 rounded-lg' />
             </NavigationLink>
+            <span className='flex-shrink-0 inline-flex items-center rounded-md bg-amber-400 px-1.5 py-0.5 text-[10px] sm:text-xs font-extrabold uppercase tracking-wider text-amber-950'>
+              Beta
+            </span>
             <div className='flex-1 relative'>
   <div ref={menuContainerRef} className='overflow-x-auto scrollbar-hide scroll-smooth'>
     <div className='flex items-center space-x-1 sm:space-x-2 min-w-max'>

--- a/components/layouts/MainLayoutClient.tsx
+++ b/components/layouts/MainLayoutClient.tsx
@@ -99,11 +99,7 @@ export default function MainLayoutClient({ children, initialLanguage }: MainLayo
               <DialogProvider>
                 <AuthRedirectHandler>
                   <Header />
-                  {!hideBetaNotice && (
-                    <div className='flex justify-center py-1 sm:py-2 bg-yellow-100'>
-                      <ExclusiveOpenBadge />
-                    </div>
-                  )}
+                  {!hideBetaNotice && <ExclusiveOpenBadge />}
                   <SubMenu />
                   <main className='flex-1 container mx-auto'>
                     {children}


### PR DESCRIPTION
## 배경
상단 AdSense Auto Ads 가 뜰 때 BETA 안내(작은 보라 pill)가 오른쪽으로 쏠려 시각적으로 나쁘고, 노출이 약해 BETA인데도 CS 문의가 들어옴.

## 원인
BETA 바가 `flex justify-center bg-yellow-100` 안의 중앙정렬 pill이라, AdSense Auto Ads 가 그 빈 중앙 컨테이너에 광고 `<ins>` 를 삽입 → pill 이 오른쪽으로 밀림 (PICNIC-WEB-5D 계열 Auto Ads 이슈).

## 변경
- **ExclusiveOpenBadge**: 작은 pill → **풀폭 amber 배너** (`Beta` 배지 + 안내문). 풀폭 solid bar 라 광고 삽입에 안 밀리고 대비가 강해 눈에 잘 띔.
- **MainLayoutClient**: 광고 삽입 표적이던 `flex justify-center bg-yellow-100` 래퍼 제거 → 배너를 직접 렌더(full-width).
- **Header**: 로고 옆 상시 **`Beta` 칩** 추가 → 스크롤·페이지 무관 항상 BETA 인지.
- ko 카피 오타 수정 `배타`→`베타`.

## 검증
- diff 3파일, orphan 스타일 없음. 시각 확인은 **Vercel Preview**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)