### PR TITLE
style(web): BETA 배너 주황 강화 + 광고 영역 분리

### DIFF
--- a/components/layouts/ExclusiveOpenBadge.tsx
+++ b/components/layouts/ExclusiveOpenBadge.tsx
@@ -40,10 +40,10 @@ const ExclusiveOpenBadge: React.FC<ExclusiveOpenBadgeProps> = ({ className = '' 
   return (
     <div
       role="status"
-      className={`w-full bg-amber-400 text-amber-950 border-b border-amber-500 ${className}`}
+      className={`w-full bg-orange-500 text-white border-b-2 border-orange-700 shadow-sm ${className}`}
     >
       <div className="container mx-auto flex items-center justify-center gap-2 px-3 py-1.5 text-center sm:py-2">
-        <span className="shrink-0 inline-flex items-center rounded bg-amber-950 px-1.5 py-0.5 text-[10px] font-extrabold uppercase tracking-wider text-amber-50 sm:text-xs">
+        <span className="shrink-0 inline-flex items-center rounded bg-white px-1.5 py-0.5 text-[10px] font-extrabold uppercase tracking-wider text-orange-700 sm:text-xs">
           Beta
         </span>
         <span className="text-xs font-semibold leading-snug sm:text-sm">

--- a/components/layouts/Header.tsx
+++ b/components/layouts/Header.tsx
@@ -150,7 +150,7 @@ const Header: React.FC = () => {
             <NavigationLink href="/" className='flex items-center flex-shrink-0'>
               <Image src='/images/logo.webp' alt='logo' width={40} height={40} priority className='w-8 h-8 sm:w-10 sm:h-10 rounded-lg' />
             </NavigationLink>
-            <span className='flex-shrink-0 inline-flex items-center rounded-md bg-amber-400 px-1.5 py-0.5 text-[10px] sm:text-xs font-extrabold uppercase tracking-wider text-amber-950'>
+            <span className='flex-shrink-0 inline-flex items-center rounded-md bg-orange-500 px-1.5 py-0.5 text-[10px] sm:text-xs font-extrabold uppercase tracking-wider text-white'>
               Beta
             </span>
             <div className='flex-1 relative'>


### PR DESCRIPTION
BETA 배너를 더 강한 주황으로 + 광고 영역과 시각적 분리.

- `ExclusiveOpenBadge`: `bg-amber-400`→`bg-orange-500`+`text-white`, BETA 배지 흰배경/주황글씨로 대비 강화.
- 배너 하단 `border-b-2 border-orange-700` + `shadow-sm` → 아래 광고 영역과 명확히 분리(배경색 bleed 방지).
- Header BETA 칩: `bg-orange-500`/`text-white` 통일.

참고: 광고 영역의 노란 배경은 **AdSense 광고 크리에이티브 자체**(advertiser 콘텐츠, 우리 CSS 아님 — 라이브 DOM 검사로 확인). 우리가 깔던 `bg-yellow-100` 광고영역 배경은 이전 PR(#30)에서 이미 제거됨.

🤖 Generated with [Claude Code](https://claude.com/claude-code)