### PR TITLE
fix(web): BETA 배너 주황 배경이 광고 영역으로 번지는 문제 해결

### DIFF
--- a/components/layouts/ExclusiveOpenBadge.tsx
+++ b/components/layouts/ExclusiveOpenBadge.tsx
@@ -37,18 +37,22 @@ const ExclusiveOpenBadge: React.FC<ExclusiveOpenBadgeProps> = ({ className = '' 
     }
   };
 
+  // 주황 배경은 콘텐츠(둥근 배너)에만 한정. 바깥 행은 흰색 → AdSense Auto Ads 가
+  // 이 근처에 광고를 주입해도 주황 배경이 광고 영역으로 번지지 않음(구조적 보장).
   return (
-    <div
-      role="status"
-      className={`w-full bg-orange-500 text-white border-b-2 border-orange-700 shadow-sm ${className}`}
-    >
-      <div className="container mx-auto flex items-center justify-center gap-2 px-3 py-1.5 text-center sm:py-2">
-        <span className="shrink-0 inline-flex items-center rounded bg-white px-1.5 py-0.5 text-[10px] font-extrabold uppercase tracking-wider text-orange-700 sm:text-xs">
-          Beta
-        </span>
-        <span className="text-xs font-semibold leading-snug sm:text-sm">
-          {getExclusiveOpenText()}
-        </span>
+    <div className={`w-full bg-white border-b border-gray-200 ${className}`}>
+      <div className="container mx-auto px-3 py-2">
+        <div
+          role="status"
+          className="flex items-center justify-center gap-2 rounded-lg bg-orange-500 px-4 py-2 text-white shadow-sm"
+        >
+          <span className="shrink-0 inline-flex items-center rounded bg-white px-1.5 py-0.5 text-[10px] font-extrabold uppercase tracking-wider text-orange-700 sm:text-xs">
+            Beta
+          </span>
+          <span className="text-xs font-semibold leading-snug sm:text-sm text-center">
+            {getExclusiveOpenText()}
+          </span>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## 문제
주황으로 바꾼 뒤 광고 영역 전체가 주황으로 표시됨. 원인은 **풀폭 `bg-orange-500` 배너 div 안에 AdSense Auto Ads 가 광고를 주입**해 주황 배경이 광고까지 덮은 것. (직전 진단에서 Playwright 에 광고가 안 떠 thin bar 로만 보여 "광고 크리에이티브" 로 오판함.)

## 해결
주황 배경을 **풀폭 블록 → 콘텐츠(둥근 배너)에 한정**. 바깥 행은 `bg-white`.
- 이제 AdSense 가 이 근처에 광고를 주입해도 흰 영역에 들어가므로 **주황이 광고로 안 번짐** (AdSense 동작에 의존하지 않는 구조적 보장).
- 여전히 강한 주황 + 굵은 텍스트 + BETA 배지로 prominent. 컨테이너 폭의 둥근 배너 형태.
- 헤더 BETA 칩(주황)은 그대로.

🤖 Generated with [Claude Code](https://claude.com/claude-code)