### PR TITLE
fix(web): /download 라우트 AdSense 비활성화 (Sentry PICNIC-WEB-5C)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -56,8 +56,13 @@ export default async function RootLayout({
   const languageMatch = pathname.match(/^\/([a-z]{2}(?:-[a-z]{2})?)(?:\/|$)/);
   const currentLang = languageMatch ? languageMatch[1] : 'ko';
 
-  const shouldLoadAds = process.env.NODE_ENV === 'production';
   const voteRoutePattern = /^\/[a-z]{2}(?:-[a-z]{2})?\/vote(?:\/|$)/i;
+  // /download 는 앱스토어로 빠르게 빠지는 landing page 라 AdSense 노출 가치가
+  // 거의 없는 반면, Auto ads / vignette 가 slow mobile 의 hydration 완료 전에
+  // DOM 을 mutate 해 PICNIC-WEB-5C 단일 culprit 으로 누적됨.
+  const downloadRoutePattern = /^\/[a-z]{2}(?:-[a-z]{2})?\/download(?:\/|$)/i;
+  const isAdFreeRoute = downloadRoutePattern.test(pathname || '');
+  const shouldLoadAds = process.env.NODE_ENV === 'production' && !isAdFreeRoute;
   const shouldDelayAds = voteRoutePattern.test(pathname || '');
 
   return (


### PR DESCRIPTION
## Summary

- PICNIC-WEB-5C (`replay_hydration_error`) — **549 events / 261 users**, culprit 100% `/:lang/download`
- Root cause: AdSense Auto ads / vignette 가 slow mobile 의 React hydration 완료 전에 DOM 을 mutate (같은 파일 line 78-81 코멘트에서 이미 식별)
- `/download` 는 앱스토어 redirect landing page 라 광고 노출 가치 ≈ 0 → delay 키우는 대신 AdSense 자체 비활성화

## Change

`app/layout.tsx` 1 file, +6/-1
- `downloadRoutePattern` 추가
- `shouldLoadAds = production && !isAdFreeRoute`

## Why this fix vs delay extension

| Option | 5C 차단 | 광고 수익 | 변경 폭 |
|--------|--------|----------|---------|
| AdSense 비활성화 (이 PR) | ✅ 완전 | landing page 라 영향 미미 | 6 줄 |
| 5000ms idle delay 로 확장 | △ (느린 디바이스에선 여전히 race) | 광고 표시 (지연) | 동일 |

vote 라우트의 5000ms delay 가 5C 를 막은 사례를 보면 delay 도 효과는 있으나, /download 는 redirect 페이지 특성상 광고 보여줄 시간 자체가 짧아 AdSense ROI 가 낮음.

## Test plan

- [x] Regex 검증: `/ko/download`, `/zh-tw/download/`, `/ko/downloads` (X), `/ko/vote` (X) 등
- [x] tsc --noEmit 통과
- [ ] Production 배포 후 PICNIC-WEB-5C 신규 이벤트 카운트 감소 확인 (3-7 일 window)

🤖 Generated with [Claude Code](https://claude.com/claude-code)