### PR TITLE
fix(web): Sentry beforeSend 필터 exception.values 전체 iterate (PICNIC-WEB-5D)

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -49,25 +49,41 @@ if (SENTRY_DSN) {
     
     // Event filtering
     beforeSend(event) {
-      // Filter out known development errors
+      // window.onerror 로 캡처된 cross-origin / 외부 에러는 Sentry SDK 가 종종
+      // outer `Error` wrapper 로 감싸 event.exception.values 에 두 entry 가
+      // 들어온다 ([{ type:'Error', value:'SecurityError: ...' },
+      // { type:'SecurityError', value:'Blocked a frame...' }] 처럼).
+      // values[0] 만 검사하면 type 매치가 실패해 노이즈가 새므로 (PR #25 이후
+      // PICNIC-WEB-5D 가 계속 firing 한 원인) 모든 시그니처 체크는 values
+      // 전체에 대해 some() 으로 매치한다.
       if (event.exception) {
-        const error = event.exception.values?.[0];
-        if (error?.value?.includes('hydration') && process.env.NODE_ENV === 'development') {
+        const values = event.exception.values ?? [];
+        type ExceptionValue = (typeof values)[number];
+        const matchesAnyValue = (predicate: (v: ExceptionValue) => boolean) =>
+          values.some(predicate);
+
+        if (
+          process.env.NODE_ENV === 'development' &&
+          matchesAnyValue((v) => v.value?.includes('hydration') ?? false)
+        ) {
           return null;
         }
+
         // Drop errors originating from third-party ad SDK frames
         // (Google AdSense / DoubleClick / Twitter in-app webview injected globals).
         // 우리 코드와 무관하며 disposed iframe race / 외부 전역 변수 미정의가 대다수.
-        const frames = error?.stacktrace?.frames ?? [];
-        const isThirdPartyAd = frames.some((f) => {
-          const fn = f.filename ?? '';
-          return (
-            fn.includes('/pagead/') ||
-            fn.includes('googlesyndication.com') ||
-            fn.includes('googletagservices.com') ||
-            fn.includes('doubleclick.net') ||
-            fn.includes('adsbygoogle')
-          );
+        const isThirdPartyAd = matchesAnyValue((v) => {
+          const frames = v.stacktrace?.frames ?? [];
+          return frames.some((f) => {
+            const fn = f.filename ?? '';
+            return (
+              fn.includes('/pagead/') ||
+              fn.includes('googlesyndication.com') ||
+              fn.includes('googletagservices.com') ||
+              fn.includes('doubleclick.net') ||
+              fn.includes('adsbygoogle')
+            );
+          });
         });
         if (isThirdPartyAd) {
           return null;
@@ -78,15 +94,16 @@ if (SENTRY_DSN) {
         // 메시지 패턴으로 추가 차단.
         //   - "Blocked a frame with origin ... cross-origin frame" (PICNIC-WEB-5D)
         //   - "The request was denied." DOMException code 18 (PICNIC-WEB-61)
-        const errType = error?.type ?? '';
-        const errValue = error?.value ?? '';
-        const isCrossOriginSecurityError =
-          errType === 'SecurityError' &&
-          (
-            errValue.includes('cross-origin frame') ||
-            errValue.includes('Blocked a frame') ||
-            errValue === 'The request was denied.'
+        const isCrossOriginSecurityError = matchesAnyValue((v) => {
+          const errType = v.type ?? '';
+          const errValue = v.value ?? '';
+          return (
+            errType === 'SecurityError' &&
+            (errValue.includes('cross-origin frame') ||
+              errValue.includes('Blocked a frame') ||
+              errValue === 'The request was denied.')
           );
+        });
         if (isCrossOriginSecurityError) {
           return null;
         }
@@ -95,13 +112,19 @@ if (SENTRY_DSN) {
         // stacktrace 가 비어 있어(`undefined:31`) 식별 불가, 우리 코드 무관.
         // /login, /download, /open-in-browser 등 무관한 라우트에서 동일 패턴
         // 발생 (Chrome iOS 100%, mechanism=onerror, 유효 frame 0). PICNIC-WEB-5T.
-        const mechType = error?.mechanism?.type ?? '';
-        const isRangeErrorFromExternal =
-          errType === 'RangeError' &&
-          errValue.includes('Maximum call stack size exceeded') &&
-          mechType === 'onerror' &&
-          (frames.length === 0 ||
-            frames.every((f) => !f.filename || f.filename === '<anonymous>'));
+        const isRangeErrorFromExternal = matchesAnyValue((v) => {
+          const errType = v.type ?? '';
+          const errValue = v.value ?? '';
+          const frames = v.stacktrace?.frames ?? [];
+          const mechType = v.mechanism?.type ?? '';
+          return (
+            errType === 'RangeError' &&
+            errValue.includes('Maximum call stack size exceeded') &&
+            mechType === 'onerror' &&
+            (frames.length === 0 ||
+              frames.every((f) => !f.filename || f.filename === '<anonymous>'))
+          );
+        });
         if (isRangeErrorFromExternal) {
           return null;
         }


### PR DESCRIPTION
## Summary

- **PICNIC-WEB-5D** 가 PR #25 이후에도 계속 firing (31 events / 1 user / Whale iOS 18.7, last seen 12h ago)
- Root cause: window.onerror 로 캡처된 cross-origin 에러를 Sentry SDK 가 outer `Error` wrapper 로 감싸 `event.exception.values` 에 두 entry 가 들어옴. 기존 필터는 `values[0]` 만 검사해서 wrapper 의 `type='Error'` 가 type 매치를 깨뜨림
- 3개 필터 (isThirdPartyAd / isCrossOriginSecurityError / isRangeErrorFromExternal) 모두 `values.some()` 으로 일괄 하드닝
- PR #26 의 5T 필터도 같은 chain 패턴이라 deploy 후 재발 위험 있었음 — 함께 차단됨

## Evidence

Sentry get_sentry_resource on 5D 최신 event 결과:
\`\`\`
### Error
SecurityError: Blocked a frame with origin "https://www.picnic.fan" from accessing a cross-origin frame.

### Error
Error: SecurityError: Blocked a frame with origin "https://www.picnic.fan" from accessing a cross-origin frame.
\`\`\`

두 entry 가 있고 outer 가 \`type='Error'\`. 동일 패턴이 5T (RangeError) event 에서도 확인됨.

## Change

\`instrumentation-client.ts\` 1 file, +51/-28 (실 로직 변화는 같음, iteration 형태로 전환)

- \`values = event.exception.values ?? []\` 추출
- \`matchesAnyValue(predicate)\` helper 도입
- 기존 3개 필터 + dev hydration 필터 모두 some() 으로 통일

## Why bundled into one PR

세 필터가 공통 root cause (values[0] 만 검사) 를 공유. 5D 만 따로 고치면 5T 가 동일 변형으로 재발 가능. memory \`user_refactor_bundling_preference\` 와 일치.

## Test plan

- [x] tsc --noEmit 통과
- [x] 로직 동등성 — values 가 1개일 때 기존 동작과 동일 (values[0].some 결과 == values[0] 단일 검사 결과)
- [ ] Production 배포 후 PICNIC-WEB-5D 신규 이벤트 0 확인 (3-7 일)
- [ ] PICNIC-WEB-5T (PR #26 머지 직후) 도 함께 모니터링

Fixes PICNIC-WEB-5D

🤖 Generated with [Claude Code](https://claude.com/claude-code)