### PR TITLE
chore(web): Sentry client sourcemap 업로드 활성화

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -23,9 +23,10 @@ const buildTime = new Date().toISOString();
 const nextConfig = {
   reactStrictMode: true,
 
-  // Source Maps 설정 - 프로덕션에서는 비활성화 (빌드 속도 개선)
-  // Sentry는 서버 소스맵만으로도 에러 추적 가능
-  productionBrowserSourceMaps: false,
+  // Sentry 가 client-side 에러를 decode 할 수 있도록 browser sourcemap 생성.
+  // Sentry plugin 의 hideSourceMaps:true 가 업로드 후 .map 파일을 삭제하므로
+  // public 노출은 없음 (`Yd` 같은 식별 불가 minified 에러를 풀기 위함).
+  productionBrowserSourceMaps: true,
   
   // 환경변수 명시적 설정 (브라우저에서 사용 가능하도록)
   env: {
@@ -184,16 +185,22 @@ const nextConfig = {
 
 const sentryWebpackPluginOptions = {
   silent: true, // 로그 비활성화
-  hideSourceMaps: true, // 소스맵 숨기기
+  hideSourceMaps: true, // 업로드 후 .map 파일 public 노출 방지
   // Sentry 조직 및 프로젝트 정보 명시적 설정
-  org: process.env.SENTRY_ORG || 'picnic-global',
+  org: process.env.SENTRY_ORG || 'icon-casting',
   project: process.env.SENTRY_PROJECT || 'picnic-web',
   authToken: process.env.SENTRY_AUTH_TOKEN,
   // 릴리즈 정보
   release: process.env.NEXT_PUBLIC_SENTRY_RELEASE || (buildVersion ? `picnic-web@${buildVersion}` : undefined),
-  // 빌드 속도 개선: 소스맵 업로드 비활성화 (필요시 CI에서 별도 실행)
-  disableServerWebpackPlugin: true,
-  disableClientWebpackPlugin: true,
+  // 기본값은 `static/chunks/pages/` + `static/chunks/app/` 만 업로드 — Supabase
+  // 등 공유 vendor 청크가 제외돼 'Yd' 같은 SDK 내부 minified 클래스가 안 풀린다.
+  // PICNIC-WEB-5S/5V 처럼 root cause 가 vendor chunk 인 케이스를 decode 하려면
+  // 모든 client chunk 가 필요.
+  widenClientFileUpload: true,
+  // SENTRY_AUTH_TOKEN 있을 때만 소스맵 업로드 (Vercel 빌드에선 활성, 로컬 빌드
+  // 에선 자동 비활성).
+  disableServerWebpackPlugin: !process.env.SENTRY_AUTH_TOKEN,
+  disableClientWebpackPlugin: !process.env.SENTRY_AUTH_TOKEN,
 };
 
 module.exports = withSentryConfig(nextConfig, sentryWebpackPluginOptions);


### PR DESCRIPTION
## Summary

Production client Sentry 이벤트가 minified 그대로 남아서 PICNIC-WEB-5S/5V 처럼 \`Error: Yd\` (식별 불가 클래스명) 같은 actionable 신호 없는 상태였음. Vercel 에는 이미 \`SENTRY_AUTH_TOKEN/ORG/PROJECT\` 설정돼 있는데 \`next.config.js\` 가 webpack plugin 을 disable 하고 \`productionBrowserSourceMaps:false\` 로 막아 둠 → sourcemap upload 활성화.

## Change

\`next.config.js\` 1 file, +15/-8

| 변경 | 효과 |
|------|------|
| \`productionBrowserSourceMaps: true\` | Next.js 가 client .map 생성 |
| \`disable{Server,Client}WebpackPlugin: !SENTRY_AUTH_TOKEN\` | Vercel 빌드에만 활성, 로컬 빌드 자동 skip → Sentry 오염 방지 |
| \`widenClientFileUpload: true\` | 기본값은 \`static/chunks/pages\` + \`static/chunks/app\` 만 업로드 — vendor 공유 청크(Supabase auth-js 등 'Yd' 가 살 가능성 높은 곳) 포함 |
| \`org\` fallback \`picnic-global\` → \`icon-casting\` | 실제 org slug 와 일치 (\`.sentryclirc\` 와 동일) |
| \`hideSourceMaps: true\` 유지 | 업로드 후 .map 삭제 → public 노출 차단 |

## Local build verification

- client 162 .map 생성 → Sentry 업로드 → hideSourceMaps 로 삭제 (\`find .next/static -name '*.map' | wc -l\` = 0)
- server .map 158 유지 (Sentry 권장 — Vercel 빌드 안정성, 정적 파일 아님)
- 로그인 청크 (\`static/chunks/app/[lang]/(auth)/login/page-*.js\`) + vendor 공유 청크 모두 포함
- 빌드 성공 (50s 컴파일, 평소와 비슷)

## Risk / Impact

| 측면 | 평가 |
|------|------|
| Build 시간 | 약간 증가 (.map 생성 + 업로드, 분당 단위 아님) |
| Bundle 크기 (사용자 측) | 변동 없음 (.map 은 production output 에서 삭제됨) |
| Sentry 비용 | sourcemap 용량 비용 미미, 이벤트 quota 영향 없음 |
| Public 노출 | hideSourceMaps:true 로 차단됨 (이미 검증) |

## Test plan

- [x] 로컬 \`npm run build\` 통과
- [x] client/server map 생성 + 업로드 + hideSourceMaps 동작 확인
- [ ] Production 배포 후 새 Sentry 이벤트가 decoded stacktrace 로 표시되는지 확인 (다음 release 부터 적용)
- [ ] PICNIC-WEB-5S/5V 재발 시 'Yd' 정체 파악 후 진짜 fix 가능

🤖 Generated with [Claude Code](https://claude.com/claude-code)