### PR TITLE
fix(web): MainLayoutClient 에 팝업 렌더링 복원

### DIFF
--- a/app/[lang]/(main)/MainLayoutClient.tsx
+++ b/app/[lang]/(main)/MainLayoutClient.tsx
@@ -7,6 +7,9 @@ import { Popup } from '@/types/interfaces';
 import Header from '@/components/layouts/Header';
 import Footer from '@/components/layouts/Footer';
 import { PicnicMenu } from '@/components/client/common/PicnicMenu';
+import PopupBanner from '@/components/client/vote/dialogs/PopupBanner';
+import { getLocalizedString } from '@/utils/api/strings';
+import { getCdnImageUrl } from '@/utils/api/image';
 
 const fetcher = (url: string) => fetch(url).then(res => res.json());
 
@@ -14,21 +17,64 @@ interface MainLayoutClientProps {
   children: React.ReactNode;
 }
 
+interface PopupSlide {
+  imageUrl: string;
+  title: string;
+  content: string;
+  popupKey: number;
+}
+
 const MainLayoutClient = ({ children }: MainLayoutClientProps) => {
   const pathname = usePathname();
   const { data: popups, error: popupsError } = useSWR<Popup[]>('/api/popups', fetcher);
-  const [activePopup, setActivePopup] = useState<Popup | null>(null);
+  const [popupSlides, setPopupSlides] = useState<PopupSlide[]>([]);
+  const [isPopupOpen, setIsPopupOpen] = useState(false);
+  const [currentSlide] = useState(0);
 
   useEffect(() => {
-    if (popups && popups.length > 0) {
-      setActivePopup(popups[0]);
-    }
+    if (!popups || popups.length === 0) return;
+
+    const now = new Date();
+    const filtered = popups.filter((popup) => {
+      const hideUntil =
+        typeof window !== 'undefined'
+          ? localStorage.getItem(`hide_popup_${popup.id}`)
+          : null;
+      if (hideUntil && new Date(hideUntil) > now) return false;
+
+      const platform = popup.platform || 'all';
+      if (!(platform === 'all' || platform === 'web')) return false;
+
+      return true;
+    });
+
+    setPopupSlides(
+      filtered.map((popup) => ({
+        imageUrl: getCdnImageUrl(getLocalizedString(popup.image)),
+        title: getLocalizedString(popup.title),
+        content: getLocalizedString(popup.content),
+        popupKey: popup.id,
+      })),
+    );
   }, [popups]);
 
-  const handleClosePopup = () => {
-    setActivePopup(null);
+  useEffect(() => {
+    if (popupSlides.length > 0) setIsPopupOpen(true);
+  }, [popupSlides]);
+
+  const handleClosePopup = () => setIsPopupOpen(false);
+
+  const handleCloseFor7Days = () => {
+    const slide = popupSlides[currentSlide];
+    if (!slide) return;
+    const hideUntil = new Date();
+    hideUntil.setDate(hideUntil.getDate() + 7);
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(`hide_popup_${slide.popupKey}`, hideUntil.toISOString());
+    }
+    setIsPopupOpen(false);
   };
-  
+
   if (popupsError) console.error('Failed to load popups', popupsError);
 
   // Firebase Analytics: mypage 섹션 포함 전역 page_view 로깅
@@ -82,6 +128,13 @@ const MainLayoutClient = ({ children }: MainLayoutClientProps) => {
       <div className="container mx-auto px-4">
         <Footer />
       </div>
+
+      <PopupBanner
+        isOpen={isPopupOpen}
+        onClose={handleClosePopup}
+        onCloseFor7Days={handleCloseFor7Days}
+        slides={popupSlides}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- 2025-07-29 커밋 [`4511b2cb`](../commit/4511b2cb) 의 `MainLayoutClient.tsx` 리팩터링에서 `<PopupBanner>` 렌더 + 7일 숨김 + platform 필터 + 다국어 매핑이 통째로 누락되어, 그 이후 모든 웹 팝업이 화면에 표시되지 않던 문제를 복구.
- `/api/popups` 데이터 fetch 와 `activePopup` state 만 남아있고 JSX 어디에서도 PopupBanner 가 렌더되지 않던 상태였음.

## Root cause
- `app/[lang]/(main)/MainLayoutClient.tsx` 가 popups 데이터를 받아 state 까지는 만들지만 `<PopupBanner ... />` 가 return JSX 에 없음.
- 결과: admin 에서 등록한 popup id=5 등 모든 활성 팝업이 노출 안 됨.

## Changes
- `PopupBanner` 컴포넌트 import + 렌더 복원
- `localStorage.hide_popup_<id>` 기반 7일 숨김 필터 복원
- `platform = 'all' | 'web'` 필터 복원
- `getLocalizedString` + `getCdnImageUrl` 으로 다국어 이미지/제목/내용 매핑 복원
- 슬라이드 인덱스(`currentSlide`) 가 PopupBanner 내부 상태와 분리되어 있어 7일 숨김 키는 첫 슬라이드 기준 (기존 동작과 동일)

## Test plan
- [ ] main 머지 후 production 에서 popup id=5 (`/popup/show/5`, platform=web, 5/27~6/4) 가 첫 진입 시 노출되는지 확인
- [ ] "7일 동안 보지 않기" 버튼이 `localStorage.hide_popup_5` 에 ISO 시간 저장하는지 DevTools 로 확인
- [ ] 닫기 후 새로고침 시 다시 안 뜨는지 확인
- [ ] localStorage 클리어 후 다시 뜨는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)