### PR TITLE
fix(web): 팝업 렌더를 ClientLayout/VoteLite 로 이동 (PR #36 follow-up)

### DIFF
--- a/app/[lang]/(main)/MainLayoutClient.tsx
+++ b/app/[lang]/(main)/MainLayoutClient.tsx
@@ -7,9 +7,6 @@ import { Popup } from '@/types/interfaces';
 import Header from '@/components/layouts/Header';
 import Footer from '@/components/layouts/Footer';
 import { PicnicMenu } from '@/components/client/common/PicnicMenu';
-import PopupBanner from '@/components/client/vote/dialogs/PopupBanner';
-import { getLocalizedString } from '@/utils/api/strings';
-import { getCdnImageUrl } from '@/utils/api/image';
 
 const fetcher = (url: string) => fetch(url).then(res => res.json());
 
@@ -17,64 +14,21 @@ interface MainLayoutClientProps {
   children: React.ReactNode;
 }
 
-interface PopupSlide {
-  imageUrl: string;
-  title: string;
-  content: string;
-  popupKey: number;
-}
-
 const MainLayoutClient = ({ children }: MainLayoutClientProps) => {
   const pathname = usePathname();
   const { data: popups, error: popupsError } = useSWR<Popup[]>('/api/popups', fetcher);
-  const [popupSlides, setPopupSlides] = useState<PopupSlide[]>([]);
-  const [isPopupOpen, setIsPopupOpen] = useState(false);
-  const [currentSlide] = useState(0);
+  const [activePopup, setActivePopup] = useState<Popup | null>(null);
 
   useEffect(() => {
-    if (!popups || popups.length === 0) return;
-
-    const now = new Date();
-    const filtered = popups.filter((popup) => {
-      const hideUntil =
-        typeof window !== 'undefined'
-          ? localStorage.getItem(`hide_popup_${popup.id}`)
-          : null;
-      if (hideUntil && new Date(hideUntil) > now) return false;
-
-      const platform = popup.platform || 'all';
-      if (!(platform === 'all' || platform === 'web')) return false;
-
-      return true;
-    });
-
-    setPopupSlides(
-      filtered.map((popup) => ({
-        imageUrl: getCdnImageUrl(getLocalizedString(popup.image)),
-        title: getLocalizedString(popup.title),
-        content: getLocalizedString(popup.content),
-        popupKey: popup.id,
-      })),
-    );
+    if (popups && popups.length > 0) {
+      setActivePopup(popups[0]);
+    }
   }, [popups]);
 
-  useEffect(() => {
-    if (popupSlides.length > 0) setIsPopupOpen(true);
-  }, [popupSlides]);
-
-  const handleClosePopup = () => setIsPopupOpen(false);
-
-  const handleCloseFor7Days = () => {
-    const slide = popupSlides[currentSlide];
-    if (!slide) return;
-    const hideUntil = new Date();
-    hideUntil.setDate(hideUntil.getDate() + 7);
-    if (typeof window !== 'undefined') {
-      localStorage.setItem(`hide_popup_${slide.popupKey}`, hideUntil.toISOString());
-    }
-    setIsPopupOpen(false);
+  const handleClosePopup = () => {
+    setActivePopup(null);
   };
-
+  
   if (popupsError) console.error('Failed to load popups', popupsError);
 
   // Firebase Analytics: mypage 섹션 포함 전역 page_view 로깅
@@ -128,13 +82,6 @@ const MainLayoutClient = ({ children }: MainLayoutClientProps) => {
       <div className="container mx-auto px-4">
         <Footer />
       </div>
-
-      <PopupBanner
-        isOpen={isPopupOpen}
-        onClose={handleClosePopup}
-        onCloseFor7Days={handleCloseFor7Days}
-        slides={popupSlides}
-      />
     </div>
   );
 };

--- a/app/[lang]/ClientLayout.tsx
+++ b/app/[lang]/ClientLayout.tsx
@@ -32,6 +32,11 @@ const LcpReporter = dynamic(
   { ssr: false, loading: () => null },
 );
 
+const PopupBannerLoader = dynamic(
+  () => import('@/components/client/common/PopupBannerLoader'),
+  { ssr: false, loading: () => null },
+);
+
 // Avatar localStorage 동기화는 제거하여 단순화
 
 interface ClientLayoutProps {
@@ -60,6 +65,7 @@ const ClientLayoutComponent = memo(function ClientLayoutInternal({
                   <LcpReporter />
                   <GlobalNotifications />
                   <GlobalLoadingOverlay />
+                  <PopupBannerLoader />
                   <Analytics />
                 </AuthRedirectHandler>
               </DialogProvider>

--- a/app/[lang]/VoteLiteClientLayout.tsx
+++ b/app/[lang]/VoteLiteClientLayout.tsx
@@ -39,6 +39,11 @@ const AuthProviderDeferred = dynamic<ProviderProps>(
   },
 );
 
+const PopupBannerLoader = dynamic(
+  () => import('@/components/client/common/PopupBannerLoader'),
+  { ssr: false, loading: () => null },
+);
+
 interface VoteLiteClientLayoutProps {
   children: React.ReactNode;
   initialLanguage: string;
@@ -54,7 +59,10 @@ const VoteLiteClientLayoutComponent = memo(function VoteLiteClientLayout({
         <GlobalLoadingProviderDeferred>
           <LanguageSyncProvider initialLanguage={initialLanguage}>
             <LcpReporter />
-            <AuthProviderDeferred>{children}</AuthProviderDeferred>
+            <AuthProviderDeferred>
+              {children}
+              <PopupBannerLoader />
+            </AuthProviderDeferred>
           </LanguageSyncProvider>
         </GlobalLoadingProviderDeferred>
       </NavigationProviderDeferred>

--- a/components/client/common/PopupBannerLoader.tsx
+++ b/components/client/common/PopupBannerLoader.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import useSWR from 'swr';
+import { Popup } from '@/types/interfaces';
+import PopupBanner from '@/components/client/vote/dialogs/PopupBanner';
+import { getLocalizedString } from '@/utils/api/strings';
+import { getCdnImageUrl } from '@/utils/api/image';
+
+const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+interface PopupSlide {
+  imageUrl: string;
+  title: string;
+  content: string;
+  popupKey: number;
+}
+
+export default function PopupBannerLoader() {
+  const { data: popups, error } = useSWR<Popup[]>('/api/popups', fetcher);
+  const [slides, setSlides] = useState<PopupSlide[]>([]);
+  const [isOpen, setIsOpen] = useState(false);
+  const [currentSlide] = useState(0);
+
+  useEffect(() => {
+    if (!popups || popups.length === 0) return;
+
+    const now = new Date();
+    const filtered = popups.filter((popup) => {
+      const hideUntil =
+        typeof window !== 'undefined'
+          ? localStorage.getItem(`hide_popup_${popup.id}`)
+          : null;
+      if (hideUntil && new Date(hideUntil) > now) return false;
+
+      const platform = popup.platform || 'all';
+      if (!(platform === 'all' || platform === 'web')) return false;
+
+      return true;
+    });
+
+    setSlides(
+      filtered.map((popup) => ({
+        imageUrl: getCdnImageUrl(getLocalizedString(popup.image)),
+        title: getLocalizedString(popup.title),
+        content: getLocalizedString(popup.content),
+        popupKey: popup.id,
+      })),
+    );
+  }, [popups]);
+
+  useEffect(() => {
+    if (slides.length > 0) setIsOpen(true);
+  }, [slides]);
+
+  if (error) console.error('Failed to load popups', error);
+
+  const handleClose = () => setIsOpen(false);
+
+  const handleCloseFor7Days = () => {
+    const slide = slides[currentSlide];
+    if (!slide) return;
+    const hideUntil = new Date();
+    hideUntil.setDate(hideUntil.getDate() + 7);
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(`hide_popup_${slide.popupKey}`, hideUntil.toISOString());
+    }
+    setIsOpen(false);
+  };
+
+  return (
+    <PopupBanner
+      isOpen={isOpen}
+      onClose={handleClose}
+      onCloseFor7Days={handleCloseFor7Days}
+      slides={slides}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- 직전 PR #36 은 잘못된 파일을 수정. `app/[lang]/(main)/MainLayoutClient.tsx` 는 `(mypage)` 만 import 하는 dead-ish 파일이라 `/vote`(홈 리다이렉트 대상) 와 `(main)` 라우트(`components/layouts/MainLayoutClient.tsx`) 에서는 여전히 팝업이 노출되지 않음.
- popup 렌더 로직을 단일 client 컴포넌트로 추출해 모든 라우트의 최상위 client 레이아웃에 mount.

## Root cause (재진단)
레이아웃 트리:
\`\`\`
[lang]/layout.tsx
├── /vote/*           → VoteLiteClientLayout   (popup 없음) ← 사용자가 보는 메인
├── /open-in-browser  → bare
└── 그 외             → ClientLayout            (popup 없음)
                         ├── (main)/layout → components/layouts/MainLayoutClient   (popup 없음)
                         ├── (mypage)/layout → (main)/MainLayoutClient ← PR #36 이 손댄 파일
                         └── (auth)
\`\`\`

## Changes
- `components/client/common/PopupBannerLoader.tsx` 신규: fetch (/api/popups, SWR) + 7일 숨김 + platform 필터 + 다국어 매핑 + `<PopupBanner>` 렌더
- `app/[lang]/ClientLayout.tsx` 에 `<PopupBannerLoader />` mount (ssr:false dynamic)
- `app/[lang]/VoteLiteClientLayout.tsx` 에 `<PopupBannerLoader />` mount (ssr:false dynamic)
- `app/[lang]/(main)/MainLayoutClient.tsx` 는 PR #36 이전 상태로 되돌림 — ClientLayout 마운트로 (mypage) 도 자동 커버, 중복 마운트 방지

## Test plan
- [ ] main 머지 후 production `/` (→`/ko/vote` 리다이렉트) 첫 진입 시 popup id=5 가 노출되는지
- [ ] `/ko/rewards`, `/ko/star-candy` 등 (main) 라우트 진입 시 노출 확인
- [ ] `/ko/mypage` 진입 시 노출 확인 (ClientLayout 경유)
- [ ] 7일 숨김 버튼 → `localStorage.hide_popup_5` 저장 확인 + 새로고침 후 안 뜸
- [ ] localStorage 클리어 후 다시 뜸

🤖 Generated with [Claude Code](https://claude.com/claude-code)