### PR TITLE
fix(web): 팝업 이미지 렌더 — aspect-video + priority 로 0높이 회색박스 해결

### DIFF
--- a/components/client/vote/dialogs/PopupBanner.tsx
+++ b/components/client/vote/dialogs/PopupBanner.tsx
@@ -121,14 +121,13 @@ const PopupBanner: React.FC<PopupBannerProps> = ({
             }`}
           >
             {/* 이미지 영역 */}
-            <div
-              className='w-full flex-shrink-0 rounded-t-lg overflow-hidden bg-gray-100'
-              style={{ position: 'relative', paddingTop: '56.25%' }}
-            >
+            <div className='relative w-full aspect-video flex-shrink-0 rounded-t-lg overflow-hidden bg-gray-100'>
               <OptimizedImage
                 src={imageUrl || '/images/logo_alpha.png'}
                 alt='popup'
                 fill
+                priority
+                sizes='(max-width: 640px) 100vw, 384px'
                 className={`${imageUrl ? 'object-cover' : 'object-contain'}`}
               />
             </div>


### PR DESCRIPTION
## Summary
PR #37 로 팝업은 뜨지만 이미지 영역이 회색 placeholder 만 표시되는 후속 버그 수정.

## Root cause
\`components/client/vote/dialogs/PopupBanner.tsx\` 의 이미지 컨테이너:
\`\`\`
<div style={{ position: 'relative', paddingTop: '56.25%' }}>
  <OptimizedImage ... fill />
</div>
\`\`\`

문제 1: \`padding-top: 56.25%\` aspect-ratio trick 은 자식이 \`position: absolute\` 여야 함. OptimizedImage 의 wrapper 는 \`relative w-full h-full\` 로 렌더 → \`h-full\` 이 0 으로 resolve → \`<Image fill />\` 가 0높이 컨테이너 안에 fill → 보이지 않음.

문제 2: \`priority\` 기본 false → IntersectionObserver fire 까지 lazy. 팝업처럼 즉시 보여야 하는 콘텐츠엔 부적합.

## Changes
- \`paddingTop: '56.25%'\` 인라인 스타일 + 자식 절대위치 의존 → modern \`aspect-video\` Tailwind 클래스 (CSS aspect-ratio)
- \`priority\` prop 추가: intersection observer 우회, 즉시 로딩
- \`sizes\` 명시 (popup max-w-sm ≈ 384px)

## Test plan
- [ ] main 머지 후 production 첫 진입 시 팝업 이미지가 정상 표시되는지
- [ ] \`localStorage.hide_popup_5\` 삭제 후 새로고침 → 이미지 + 텍스트 정상 노출
- [ ] 외부 popup id (이미지 다른) 추가 시도해도 정상 표시 (필요시)

🤖 Generated with [Claude Code](https://claude.com/claude-code)