### PR TITLE
refactor(vote): PIC CHART을 area(areas) 기반 필터로 통일

### DIFF
--- a/__tests__/lib/data-fetching/client/vote-service.test.ts
+++ b/__tests__/lib/data-fetching/client/vote-service.test.ts
@@ -187,12 +187,12 @@ describe('vote-service.client', () => {
       expect(mockQuery.contains).toHaveBeenCalledWith('areas', ['kpop']);
     });
 
-    it('should apply pic-chart area filter using vote_category', async () => {
+    it('should apply pic-chart area filter using areas array', async () => {
       const client = createMockSupabaseClient({ data: [] });
       await getVotesClient(client as any, undefined, 'pic-chart');
 
       const mockQuery = client._mockQuery;
-      expect(mockQuery.in).toHaveBeenCalledWith('vote_category', ['image', 'weekly']);
+      expect(mockQuery.contains).toHaveBeenCalledWith('areas', ['pic-chart']);
     });
 
     it('should not apply area filter for "all"', async () => {

--- a/lib/data-fetching/client/vote-service.client.ts
+++ b/lib/data-fetching/client/vote-service.client.ts
@@ -129,13 +129,8 @@ function buildVoteQuery(
 
   // 지역/타입 필터링 - 'all'인 경우 필터링하지 않음
   if (area && area !== VOTE_AREAS.ALL) {
-    if (area === VOTE_AREAS.PIC_CHART) {
-      // PIC-CHART: vote_category가 'image' 또는 'weekly'인 것
-      query = query.in("vote_category", ['image', 'weekly']);
-    } else {
-      // K-POP, K-MUSICAL: areas 배열에 해당 값이 포함되어 있는지 확인
-      query = query.contains("areas", [area]);
-    }
+    // 모든 area 탭(pic-chart 포함) — areas 배열에 값 포함 여부로 필터
+    query = query.contains("areas", [area]);
   }
 
   const { column, ascending } = getVoteOrderConfig(status);

--- a/lib/data-fetching/server/vote-service-query.ts
+++ b/lib/data-fetching/server/vote-service-query.ts
@@ -182,13 +182,8 @@ export function buildVoteQuery(
 
   // 지역/타입 필터링 - 'all'인 경우 필터링하지 않음
   if (area && area !== VOTE_AREAS.ALL) {
-    if (area === VOTE_AREAS.PIC_CHART) {
-      // PIC-CHART: vote_category가 'image' 또는 'weekly'인 것
-      query = query.in("vote_category", ['image', 'weekly']);
-    } else {
-      // K-POP, K-MUSICAL: areas 배열에 해당 값이 포함되어 있는지 확인
-      query = query.contains("areas", [area]);
-    }
+    // 모든 area 탭(pic-chart 포함) — areas 배열에 값 포함 여부로 필터
+    query = query.contains("areas", [area]);
   }
 
   const { column, ascending } = getVoteOrderConfig(status);


### PR DESCRIPTION
## 개요
투표 목록의 PIC CHART 탭 필터를 카테고리 sentinel에서 **`areas @> ['pic-chart']`**(다른 area 탭과 동일)로 통일합니다.

## 배경
`area==='pic-chart'`일 때만 `.in('vote_category',['image','weekly'])`로 특수 처리하던 분기가 server/client 양쪽에 있었습니다. **DB 마이그레이션이 이미 프로덕션에 반영**되어 image 투표는 `areas=['pic-chart']`를 가집니다.

## 변경
- `lib/data-fetching/server/vote-service-query.ts`
- `lib/data-fetching/client/vote-service.client.ts`

두 곳 모두 pic-chart 분기 제거 → 항상 `query.contains('areas',[area])`. 구 sentinel을 검증하던 테스트도 `.contains('areas',['pic-chart'])`로 갱신.

## 효과
PIC CHART = image 전용(weekly는 PICNIC). 앱과 weekly 취급 불일치도 해소.

## 검증
`tsc --noEmit` 0, vote-service 테스트 16/16, `npm run build` 성공. server/client parity 확인.

## 배포 노트
DB 이미 반영됨(non-breaking). 권장 배포 순서: web → app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
